### PR TITLE
Implement Debug for ZipEntry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod write;
 use error::{Result, ZipError};
 
 /// A compression method supported by this crate.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Compression {
     Stored,
     Deflate,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -22,6 +22,7 @@ use crc32fast::Hasher;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, BufReader, ReadBuf, Take};
 
 /// An entry within a larger ZIP file reader.
+#[derive(Debug)]
 pub struct ZipEntry {
     pub(crate) name: String,
     pub(crate) comment: Option<String>,


### PR DESCRIPTION
As well as `Compression` which is a field of `ZipEntry`. Makes debugging easier by not having to call all the getter methods and print their return values one by one.