### PR TITLE
Implement Display and Error for ZipError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ async-compression = { version = "0.3.8", features = ["tokio", "deflate", "bzip2"
 tokio = { version = "1.12.0", features = ["io-util", "fs"] }
 chrono = "0.4.19"
 crc32fast = "1.2.1"
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["full"] }


### PR DESCRIPTION
For better interop. The impls (as well as the existing `From<io::Error>` impl) are derived via the [`thiserror`](https://docs.rs/thiserror) crate, and the existing `description` method is reimplemented in terms of `Display` to avoid code duplication.