### PR TITLE
Add possibility to select unix permissions for compressed files

### DIFF
--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -64,7 +64,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             flags: lf_header.flags,
             disk_start: 0,
             inter_attr: 0,
-            exter_attr: 0,
+            exter_attr: self.opts.unix_permissions << 16,
             lh_offset: self.writer.writer.offset() as u32,
         };
 

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -70,7 +70,13 @@ pub struct EntryOptions {
 impl EntryOptions {
     /// Construct a new set of options from its required constituents.
     pub fn new(filename: String, compression: Compression) -> Self {
-        EntryOptions { filename, compression, extra: Vec::new(), comment: String::new() }
+        EntryOptions { 
+            filename, 
+            compression,
+            extra: Vec::new(),
+            comment: String::new(),
+            unix_permissions: 0,
+        }
     }
 
     /// Consume the options and override the extra field data.

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -64,6 +64,7 @@ pub struct EntryOptions {
     pub(crate) compression: Compression,
     extra: Vec<u8>,
     comment: String,
+    unix_permissions: u32,
 }
 
 impl EntryOptions {
@@ -81,6 +82,12 @@ impl EntryOptions {
     /// Consume the options and override the file comment.
     pub fn comment(mut self, comment: String) -> Self {
         self.comment = comment;
+        self
+    }
+
+    /// Consume unix permissions option for zip files (ex. 0o755)
+    pub fn unix_permissions(mut self, unix_permissions: u32) -> Self {
+        self.unix_permissions = unix_permissions;
         self
     }
 }


### PR DESCRIPTION
ISSUE: currently this library for unix/linux zipping assign 0-based permissions 0x000, which does not allow to open files after unzip (unless manually permissions changed). 

This MR adds possibility to set the the Unix permissions for the all zipped files with selected value ex. 0x755

Usage:
`
    let entry_options = EntryOptions::new(name.into(), Compression::Deflate)
        .unix_permissions(0o755);
`

It is initial version as pre-solution for #14 - just instead of preventing file permissions it allows to set them. 
Similar solution is applied in sync version of Rust zip library: https://github.com/zip-rs/zip 