### PR TITLE
Use read_exact instead of read when parsing headers

### DIFF
--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -40,7 +40,7 @@ impl GeneralPurposeFlag {
             false => 0x0,
             true => 0x800,
         };
-        
+
         (encrypted | data_descriptor | filename_unicode).to_le_bytes()
     }
 }
@@ -155,7 +155,7 @@ impl From<[u8; 18]> for EndOfCentralDirectoryHeader {
 impl LocalFileHeader {
     pub async fn from_reader<R: AsyncRead + Unpin>(reader: &mut R) -> Result<LocalFileHeader> {
         let mut buffer: [u8; 26] = [0; 26];
-        reader.read(&mut buffer).await?;
+        reader.read_exact(&mut buffer).await?;
         Ok(LocalFileHeader::from(buffer))
     }
 }
@@ -163,7 +163,7 @@ impl LocalFileHeader {
 impl EndOfCentralDirectoryHeader {
     pub async fn from_reader<R: AsyncRead + Unpin>(reader: &mut R) -> Result<EndOfCentralDirectoryHeader> {
         let mut buffer: [u8; 18] = [0; 18];
-        reader.read(&mut buffer).await?;
+        reader.read_exact(&mut buffer).await?;
         Ok(EndOfCentralDirectoryHeader::from(buffer))
     }
 }
@@ -171,7 +171,7 @@ impl EndOfCentralDirectoryHeader {
 impl CentralDirectoryHeader {
     pub async fn from_reader<R: AsyncRead + Unpin>(reader: &mut R) -> Result<CentralDirectoryHeader> {
         let mut buffer: [u8; 42] = [0; 42];
-        reader.read(&mut buffer).await?;
+        reader.read_exact(&mut buffer).await?;
         Ok(CentralDirectoryHeader::from(buffer))
     }
 }


### PR DESCRIPTION
Read can receive less than the buffer size.
It usually doesn't but it may cause intermittent issues without read_exact.