### PR TITLE
Fix poll_read leaving the stream in a non-valid state

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -162,6 +162,65 @@ async fn data_descriptor_double_stream() {
     assert!(zip_reader.finished());
 }
 
+#[cfg(feature = "deflate")]
+#[tokio::test]
+async fn data_tokio_copy_stream() {
+    use crate::read::stream::ZipFileReader;
+    use tokio::io::AsyncWriteExt;
+
+    let mut input_stream = Cursor::new(Vec::<u8>::new());
+
+    let mut zip_writer = ZipFileWriter::new(&mut input_stream);
+    let data = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt...";
+
+    let open_opts = EntryOptions::new("foo.bar".to_string(), Compression::Deflate);
+    let mut entry_writer = zip_writer.write_entry_stream(open_opts).await.expect("failed to open write entry");
+    entry_writer.write_all(data.as_bytes()).await.expect("failed to write entry");
+    entry_writer.close().await.expect("failed to close entry");
+
+    let open_opts = EntryOptions::new("test.bar".to_string(), Compression::Deflate);
+    let mut entry_writer = zip_writer.write_entry_stream(open_opts).await.expect("failed to open write entry");
+    entry_writer.write_all(data.as_bytes()).await.expect("failed to write entry");
+    entry_writer.close().await.expect("failed to close entry");
+
+    zip_writer.close().await.expect("failed to close writer");
+
+    input_stream.set_position(0);
+
+    let mut zip_reader = ZipFileReader::new(&mut input_stream);
+
+    assert!(!zip_reader.finished());
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_some());
+
+    let mut entry_reader = entry_reader.unwrap();
+
+    let mut output_stream = Cursor::new(Vec::<u8>::new());
+
+    assert_ne!(tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy"), 0);
+    assert_eq!(tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy"), 0);
+
+    assert!(entry_reader.compare_crc());
+    assert_eq!(data, String::from_utf8(output_stream.into_inner()).expect("failed to read entry to string"));
+
+    assert!(!zip_reader.finished());
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_some());
+    let mut entry_reader = entry_reader.unwrap();
+
+    let mut output_stream = Cursor::new(Vec::<u8>::new());
+    tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy");
+
+    assert!(entry_reader.compare_crc());
+    assert_eq!(data, String::from_utf8(output_stream.into_inner()).expect("failed to read entry to string"));
+
+    assert!(!zip_reader.finished());
+
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_none());
+    assert!(zip_reader.finished());
+}
+
 macro_rules! single_entry_gen {
     ($name:ident, $typ:expr) => {
         #[tokio::test]


### PR DESCRIPTION
Trying to read the `stream::ZipEntry` with the regular async `poll_ready` API causes the stream to be left in a non-valid state.

## Reason

That's caused mainly because we use fixed buffer sizes (like tokio's `8192` buffer size), 
and we don't know how many bytes a entry has (or will have) beforehand to set the read boundary,
so we read not only the data of the current entry, but also the data of the next entry.

That's is not a problem, `AsyncDelimiterReader` provides access to the inner buffer, so we can just take the exceeding bytes and prepend it using `AsyncPrependReader`.

The real problem is, the function that does this is the `reset_reader`, and it **must** be called before trying to read the next entry,
so the bytes *stolen* from the next `Entry` returns to the `inner` Reader as non-consumed bytes. And the other problem is, this function uses the `async` mechanism, that cannot be used inside `poll_*` functions (not only because they are not async, but also because they requires *Pinning*).

## Solution

The entire `reset_reader` function was removed, `read_to_end_crc` and `read_to_string_crc` does not call it anymore. The entire mechanism was moved to `poll_data_descriptor`, so any caller that uses `AsyncRead` API automatically triggers the entire logic of consuming the *Data Descriptor* bytes and returning the *stolen* bytes to the `inner` Reader.

The implementation is “a bit” more complex (actually, considerably more complex IMO), it uses a State Machine to track the state the last `Poll::Pending` left, and the already consumed data.

There are 3 states: 

- `ReadData`
  - The still data being read, we haven't reached the end of the compressed content
- `ReadDescriptor`
  - We reached the end of the compressed content and we don't have a *Data Descriptor* set,
    so we need to consume the next bytes to construct the *Data Descriptor* and return the *stolen* bytes.
- `PrepareNext`
  - We've read the *Data Descriptor* section and now we need to return the *stolen* bytes. or
  - We have the *Data Descriptor* set (found in *Local file header*), therefore no *Data Descriptor* will be present, but we still need to return the *stolen* bytes.
  - Actually, the *Data Descriptor* is set in this step, not in the previous one, just to conform to Rust borrowing rules, otherwise
    the code would need to have more scope delimiters, which I did before, but was too messier to keep.

## Considerations

During the implementation of the fix, I found some issues:

- Zip64 is not entirely supported, it uses 64-bit (8 bytes) for `compressed` and `uncompressed` fields, but the current implementation is using `u32` (4 bytes) to store those values.
- The absence of the *Data Descriptor* is not handled (wasn't before and isn't in the current implementation), 
  - Although it is expected to exists when those values are not present in the *Local file header*, 
    they are not really required, and surely there are some wild Zips which does not follow the recommendations.
    It would be good to be more tolerant to these cases, but I don't know if it does worth it (altho, the effort is very low to handle this).
- `compare_crc` may panic, I don't know if it will now, but it did before the fix (because of the *Data Descriptor* absence)
  - I think that it would be better for it to return `Result<bool>`, mainly if there's a plan to be tolerant over the absence of
    the *Data Descriptor*.
    Also, it is always a good idea for APIs to never panic, if they do inside a Thread managed by a Runtime like Tokio, it's not a big deal, but if they do in event-loop based implementations, or in anything that runs on Main Thread, it would be very dangerous.

## Final words

That's my first contribution to this repo (actually, my first contribution to an Open-Source Project after a while), any suggestions/critics are welcome.

> There may be some typos in this PR, it's very late here and the PR is a little extensive, so forgive me for any grammatical confusion.