### PR TITLE
Revert c05c5f51bd8ed0a9a782642957e1c47ba8798dab

### DIFF
--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -26,14 +26,14 @@
 //! ```
 
 use crate::error::{Result, ZipError};
-use crate::read::{CompressionReader, OwnedReader, PrependReader, ZipEntry, ZipEntryReader};
+use crate::read::{CompressionReader, ZipEntry, ZipEntryReader, OwnedReader, PrependReader};
 use crate::spec::compression::Compression;
 use crate::spec::header::{CentralDirectoryHeader, EndOfCentralDirectoryHeader, LocalFileHeader};
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
-use async_io_utilities::AsyncDelimiterReader;
 use std::io::SeekFrom;
+use async_io_utilities::AsyncDelimiterReader;
 
 /// A reader which acts over a seekable source.
 pub struct ZipFileReader<R: AsyncRead + AsyncSeek + Unpin> {
@@ -80,10 +80,8 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
     }
 }
 
-pub(crate) async fn read_cd<R: AsyncRead + AsyncSeek + Unpin>(
-    reader: &mut R,
-) -> Result<(Vec<ZipEntry>, Option<String>)> {
-    const MAX_ENDING_LENGTH: u64 = u16::MAX as u64 + 22;
+pub(crate) async fn read_cd<R: AsyncRead + AsyncSeek + Unpin>(reader: &mut R) -> Result<(Vec<ZipEntry>, Option<String>)> {
+    const MAX_ENDING_LENGTH: u64 = (u16::MAX - 2) as u64;
 
     let length = reader.seek(SeekFrom::End(0)).await?;
     let seek_to = length.saturating_sub(MAX_ENDING_LENGTH);


### PR DESCRIPTION
Reverts #23, through bisecting I found that this change breaks this zip file: https://github.com/webxdc/ChessBoard.xdc/releases/download/1.0.0/chess.xdc with 

```
Error: UnexpectedHeaderError(
    0,
    101010256,
)
```
