### PR TITLE
Refactor - Remove AsyncDelimiterReader use for Stream zip reading

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,4 +23,6 @@ pub enum ZipError {
     CRC32CheckError,
     #[error("Entry index was out of bounds.")]
     EntryIndexOutOfBounds,
+    #[error("Compressed size is required to be present in the Local File Header when using Stored compression.")]
+    MissingCompressedSize,
 }

--- a/src/read/fs.rs
+++ b/src/read/fs.rs
@@ -64,7 +64,7 @@ impl ZipFileReader {
 
         let reader = OwnedReader::Owned(fs_file);
         let reader = PrependReader::Normal(reader);
-        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into))?;
 
         Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }

--- a/src/read/fs.rs
+++ b/src/read/fs.rs
@@ -67,15 +67,16 @@ impl ZipFileReader {
             let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
             let reader = OwnedReader::Owned(fs_file);
             let reader = PrependReader::Normal(reader);
-            let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader.take(u64::MAX));
+            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
+            let reader = CompressionReader::from_reader(entry.compression(), reader);
 
-            Ok(ZipEntryReader::with_data_descriptor(entry, reader, true))
+            Ok(ZipEntryReader::from_raw(entry, reader, true))
         } else {
             let reader = OwnedReader::Owned(fs_file);
             let reader = PrependReader::Normal(reader);
-            let reader = reader.take(entry.compressed_size.unwrap().into());
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+            let reader = reader;
+            let reader =
+                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
 
             Ok(ZipEntryReader::from_raw(entry, reader, false))
         }

--- a/src/read/fs.rs
+++ b/src/read/fs.rs
@@ -28,11 +28,10 @@ use crate::error::{Result, ZipError};
 use crate::read::{OwnedReader, PrependReader, ZipEntry, ZipEntryReader};
 use crate::spec::header::LocalFileHeader;
 
-use async_io_utilities::AsyncDelimiterReader;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::io::AsyncSeekExt;
 
 /// A reader which acts concurrently over a filesystem file.
 pub struct ZipFileReader {
@@ -63,22 +62,10 @@ impl ZipFileReader {
         let data_offset = (header.file_name_length + header.extra_field_length) as i64;
         fs_file.seek(SeekFrom::Current(data_offset)).await?;
 
-        if entry.data_descriptor() {
-            let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
-            let reader = OwnedReader::Owned(fs_file);
-            let reader = PrependReader::Normal(reader);
-            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+        let reader = OwnedReader::Owned(fs_file);
+        let reader = PrependReader::Normal(reader);
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
 
-            Ok(ZipEntryReader::from_raw(entry, reader, true))
-        } else {
-            let reader = OwnedReader::Owned(fs_file);
-            let reader = PrependReader::Normal(reader);
-            let reader = reader;
-            let reader =
-                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
-
-            Ok(ZipEntryReader::from_raw(entry, reader, false))
-        }
+        Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }
 }

--- a/src/read/mem.rs
+++ b/src/read/mem.rs
@@ -43,7 +43,7 @@ impl<'a> ZipFileReader<'a> {
 
         let reader = OwnedReader::Owned(cursor);
         let reader = PrependReader::Normal(reader);
-        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into))?;
 
         Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }

--- a/src/read/mem.rs
+++ b/src/read/mem.rs
@@ -46,15 +46,15 @@ impl<'a> ZipFileReader<'a> {
             let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
             let reader = OwnedReader::Owned(cursor);
             let reader = PrependReader::Normal(reader);
-            let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader.take(u64::MAX));
+            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
+            let reader = CompressionReader::from_reader(entry.compression(), reader);
 
-            Ok(ZipEntryReader::with_data_descriptor(entry, reader, true))
+            Ok(ZipEntryReader::from_raw(entry, reader, true))
         } else {
             let reader = OwnedReader::Owned(cursor);
             let reader = PrependReader::Normal(reader);
-            let reader = reader.take(entry.compressed_size.unwrap().into());
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+            let reader =
+                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
 
             Ok(ZipEntryReader::from_raw(entry, reader, false))
         }

--- a/src/read/mem.rs
+++ b/src/read/mem.rs
@@ -9,8 +9,7 @@ use crate::spec::header::LocalFileHeader;
 
 use std::io::{Cursor, SeekFrom};
 
-use async_io_utilities::AsyncDelimiterReader;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::io::AsyncSeekExt;
 
 /// The type returned as an entry reader within this concurrent module.
 pub type ConcurrentReader<'b, 'a> = ZipEntryReader<'b, Cursor<&'a [u8]>>;
@@ -42,21 +41,10 @@ impl<'a> ZipFileReader<'a> {
         let data_offset = (header.file_name_length + header.extra_field_length) as i64;
         cursor.seek(SeekFrom::Current(data_offset)).await?;
 
-        if entry.data_descriptor() {
-            let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
-            let reader = OwnedReader::Owned(cursor);
-            let reader = PrependReader::Normal(reader);
-            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+        let reader = OwnedReader::Owned(cursor);
+        let reader = PrependReader::Normal(reader);
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
 
-            Ok(ZipEntryReader::from_raw(entry, reader, true))
-        } else {
-            let reader = OwnedReader::Owned(cursor);
-            let reader = PrependReader::Normal(reader);
-            let reader =
-                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
-
-            Ok(ZipEntryReader::from_raw(entry, reader, false))
-        }
+        Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -357,7 +357,7 @@ impl<'a, R: AsyncRead + Unpin> AsyncRead for ZipEntryReader<'a, R> {
 
                     self.consumed = true;
 
-                    if self.data_descriptor.is_none() {
+                    if self.data_descriptor.is_none() && self.entry().data_descriptor() {
                         self.state = State::ReadDescriptor([0u8; 16], 0);
 
                         self.poll_data_descriptor(c)

--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -63,7 +63,7 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
 
         let reader = OwnedReader::Borrow(&mut self.reader);
         let reader = PrependReader::Normal(reader);
-        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into))?;
 
         Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }

--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -98,7 +98,7 @@ pub(crate) async fn read_cd<R: AsyncRead + AsyncSeek + Unpin>(
     'outer: loop {
         'inner: loop {
             let mut buffer = [0; async_io_utilities::SUGGESTED_BUFFER_SIZE];
-            if reader.read_exact(&mut buffer).await? == 0 {
+            if reader.read(&mut buffer).await? == 0 {
                 break 'inner;
             }
         }

--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -65,15 +65,15 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
             let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
             let reader = OwnedReader::Borrow(&mut self.reader);
             let reader = PrependReader::Normal(reader);
-            let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader.take(u64::MAX));
+            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
+            let reader = CompressionReader::from_reader(entry.compression(), reader);
 
-            Ok(ZipEntryReader::with_data_descriptor(entry, reader, false))
+            Ok(ZipEntryReader::from_raw(entry, reader, false))
         } else {
             let reader = OwnedReader::Borrow(&mut self.reader);
             let reader = PrependReader::Normal(reader);
-            let reader = reader.take(entry.compressed_size.unwrap().into());
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+            let reader =
+                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
 
             Ok(ZipEntryReader::from_raw(entry, reader, false))
         }

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -2,14 +2,14 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 //! A module for reading ZIP files from a non-seekable source.
-//! 
+//!
 //! ## Note
 //! This method fully relies on the information provided in each individual local file header. As a result, this method
 //! doesn't support entries which desynchronise the information provided in the local file header VS the central
-//! directory file header. This is a practice that the 
+//! directory file header. This is a practice that the
 //! [specification suggests](https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#719) when you wish to
 //! conceal that information.
-//! 
+//!
 //! ## Example
 //! ```no_run
 //! # use async_zip::read::stream::ZipFileReader;
@@ -53,7 +53,7 @@ impl<R: AsyncRead + Unpin> ZipFileReader<R> {
     }
 
     /// Returns whether or not it's possible for this reader to yeild more entries.
-    /// 
+    ///
     /// # Note
     /// It's still possible for this function to return false whilst a call to [`ZipFileReader::entry_reader()`]
     /// returns no entry. This happens in the case where the last entry has been read but the central directory has not
@@ -63,7 +63,7 @@ impl<R: AsyncRead + Unpin> ZipFileReader<R> {
     }
 
     /// Opens the next entry for reading if the central directory hasn't yet been reached.
-    /// 
+    ///
     /// # Note
     /// It's essential that each entry reader returned by this function is fully consumed before a new one is opened.
     pub async fn entry_reader(&mut self) -> Result<Option<ZipEntryReader<'_, R>>> {
@@ -84,7 +84,7 @@ impl<R: AsyncRead + Unpin> ZipFileReader<R> {
             entry_borrow.compression(),
             reader,
             entry_borrow.compressed_size.map(u32::into),
-        );
+        )?;
 
         Ok(Some(ZipEntryReader::from_raw(entry_borrow, reader, entry_borrow.data_descriptor())))
     }

--- a/src/read/sync.rs
+++ b/src/read/sync.rs
@@ -61,15 +61,15 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
             let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
             let reader = OwnedReader::Owned(guarded_reader);
             let reader = PrependReader::Normal(reader);
-            let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader.take(u64::MAX));
+            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
+            let reader = CompressionReader::from_reader(entry.compression(), reader);
 
-            Ok(ZipEntryReader::with_data_descriptor(entry, reader, true))
+            Ok(ZipEntryReader::from_raw(entry, reader, true))
         } else {
             let reader = OwnedReader::Owned(guarded_reader);
             let reader = PrependReader::Normal(reader);
-            let reader = reader.take(entry.compressed_size.unwrap().into());
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+            let reader =
+                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
 
             Ok(ZipEntryReader::from_raw(entry, reader, false))
         }

--- a/src/read/sync.rs
+++ b/src/read/sync.rs
@@ -58,7 +58,7 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
 
         let reader = OwnedReader::Owned(guarded_reader);
         let reader = PrependReader::Normal(reader);
-        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into))?;
 
         Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }

--- a/src/read/sync.rs
+++ b/src/read/sync.rs
@@ -24,8 +24,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
-use async_io_utilities::AsyncDelimiterReader;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, ReadBuf};
 
 /// A reader which acts concurrently over an in-memory buffer.
 pub struct ZipFileReader<R: AsyncRead + AsyncSeek + Unpin> {
@@ -57,22 +56,11 @@ impl<R: AsyncRead + AsyncSeek + Unpin> ZipFileReader<R> {
         let data_offset = (header.file_name_length + header.extra_field_length) as i64;
         guarded_reader.seek(SeekFrom::Current(data_offset)).await?;
 
-        if entry.data_descriptor() {
-            let delimiter = crate::spec::signature::DATA_DESCRIPTOR.to_le_bytes();
-            let reader = OwnedReader::Owned(guarded_reader);
-            let reader = PrependReader::Normal(reader);
-            //let reader = AsyncDelimiterReader::new(reader, &delimiter);
-            let reader = CompressionReader::from_reader(entry.compression(), reader);
+        let reader = OwnedReader::Owned(guarded_reader);
+        let reader = PrependReader::Normal(reader);
+        let reader = CompressionReader::from_reader(entry.compression(), reader, entry.compressed_size.map(u32::into));
 
-            Ok(ZipEntryReader::from_raw(entry, reader, true))
-        } else {
-            let reader = OwnedReader::Owned(guarded_reader);
-            let reader = PrependReader::Normal(reader);
-            let reader =
-                CompressionReader::from_reader_take(entry.compression(), reader, entry.compressed_size.unwrap().into());
-
-            Ok(ZipEntryReader::from_raw(entry, reader, false))
-        }
+        Ok(ZipEntryReader::from_raw(entry, reader, entry.data_descriptor()))
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -162,6 +162,65 @@ async fn data_descriptor_double_stream() {
     assert!(zip_reader.finished());
 }
 
+#[cfg(feature = "deflate")]
+#[tokio::test]
+async fn data_tokio_copy_stream() {
+    use crate::read::stream::ZipFileReader;
+    use tokio::io::AsyncWriteExt;
+
+    let mut input_stream = Cursor::new(Vec::<u8>::new());
+
+    let mut zip_writer = ZipFileWriter::new(&mut input_stream);
+    let data = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt...";
+
+    let open_opts = EntryOptions::new("foo.bar".to_string(), Compression::Deflate);
+    let mut entry_writer = zip_writer.write_entry_stream(open_opts).await.expect("failed to open write entry");
+    entry_writer.write_all(data.as_bytes()).await.expect("failed to write entry");
+    entry_writer.close().await.expect("failed to close entry");
+
+    let open_opts = EntryOptions::new("test.bar".to_string(), Compression::Deflate);
+    let mut entry_writer = zip_writer.write_entry_stream(open_opts).await.expect("failed to open write entry");
+    entry_writer.write_all(data.as_bytes()).await.expect("failed to write entry");
+    entry_writer.close().await.expect("failed to close entry");
+
+    zip_writer.close().await.expect("failed to close writer");
+
+    input_stream.set_position(0);
+
+    let mut zip_reader = ZipFileReader::new(&mut input_stream);
+
+    assert!(!zip_reader.finished());
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_some());
+
+    let mut entry_reader = entry_reader.unwrap();
+
+    let mut output_stream = Cursor::new(Vec::<u8>::new());
+
+    assert_ne!(tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy"), 0);
+    assert_eq!(tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy"), 0);
+
+    assert!(entry_reader.compare_crc());
+    assert_eq!(data, String::from_utf8(output_stream.into_inner()).expect("failed to read entry to string"));
+
+    assert!(!zip_reader.finished());
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_some());
+    let mut entry_reader = entry_reader.unwrap();
+
+    let mut output_stream = Cursor::new(Vec::<u8>::new());
+    tokio::io::copy(&mut entry_reader, &mut output_stream).await.expect("failed to copy");
+
+    assert!(entry_reader.compare_crc());
+    assert_eq!(data, String::from_utf8(output_stream.into_inner()).expect("failed to read entry to string"));
+
+    assert!(!zip_reader.finished());
+
+    let entry_reader = zip_reader.entry_reader().await.expect("failed to open entry reader");
+    assert!(entry_reader.is_none());
+    assert!(zip_reader.finished());
+}
+
 macro_rules! single_entry_gen {
     ($name:ident, $typ:expr) => {
         #[tokio::test]


### PR DESCRIPTION
This is sort of a continuation of my previous PR: #26.

As me and @mobad [discussed in the PR](https://github.com/Majored/rs-async-zip/pull/26#issuecomment-1172969788), all the decoding algorithms **rs-async-zip** uses happens to be self-terminating, which means we don't really need the `AsyncDelimiterReader` to detect the signature of *Data descriptor*.

Those changes are a little aggressive: 

- Removed `LocalReader` and made `Stored` wrap a `Take<BufReader<R>>` instead of `Take<R>` 
  - This way I can unwrap the `BufReader` from all variants without hard specializing for the `Stored` case.
- Move *Data Descriptor* check to `poll_read`
- Change all readers to use `ZipEntryReader::from_raw`
- Take away `AsyncDelimiterReader` for *Data Descriptor* (only for *Data Descriptor*, because it still used in other place(s)).
- `CompressionReader::from_reader` may now fail, since `Stored` mode **requires** the size to be known.

There are some caveats in those changes:

**Now *Data Descriptor* parsing is not tied to `Stream` mode**

This means that other readers, like the ones that impls `Seek`, will also cause the *Data Descriptor* logic to happen. But it is only true if the *Zip Entry* has the Data Descriptor flag set (`0x8`), if they do not, the logic will skip the *Data Descriptor* part and proceed right to the *PrepareNext* state.

We can avoid this by skipping this part if `ZipEntry` has `crc32` set (and not equal to zero).

The downside is that we pay for the overhead of parsing and checking for the *Data Descriptor* even if we can seek directly to the Central Directory to retrieve this data.

## Note

This PR is based on the #26 branch, if you wish to merge this instead of #26, we can just close #26. But if you prefer to do a two step change to see how things behaves (because this one seems to be bigger and more impactful than the other), we can merge #26 first.