### PR TITLE
Handle the panic when copying the buffer

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -330,7 +330,7 @@ impl<'a, R: AsyncRead + Unpin> ZipEntryReader<'a, R> {
     /// place.
     pub async fn copy_to_end_crc<W: AsyncWrite + Unpin>(mut self, writer: &mut W, buffer: usize) -> Result<()> {
         let mut reader = BufReader::with_capacity(buffer, &mut self);
-        tokio::io::copy_buf(&mut reader, writer).await.unwrap();
+        tokio::io::copy_buf(&mut reader, writer).await?;
 
         if self.compare_crc() {
             Ok(())


### PR DESCRIPTION
Firstly, thanks @Majored for awesome work with this library!

I noticed that the `copy_to_end_crc` function tends to panic when underlying tokio process returns an error. Since this is breaking my application, here's one-liner fix for that.