### PR TITLE
Allow entry modification time to be set explicitly

### DIFF
--- a/src/write/entry_stream.rs
+++ b/src/write/entry_stream.rs
@@ -48,7 +48,11 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
     }
 
     async fn write_lfh(writer: &'b mut ZipFileWriter<W>, options: &EntryOptions) -> Result<LocalFileHeader> {
-        let (mod_time, mod_date) = crate::spec::date::chrono_to_zip_time(&Utc::now());
+        let (mod_time, mod_date) = if let Some(last_modified) = &options.last_modified {
+            crate::spec::date::chrono_to_zip_time(last_modified)
+        } else {
+            crate::spec::date::chrono_to_zip_time(&Utc::now())
+        };
 
         let lfh = LocalFileHeader {
             compressed_size: 0,

--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -37,7 +37,11 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             }
         };
 
-        let (mod_time, mod_date) = crate::spec::date::chrono_to_zip_time(&Utc::now());
+        let (mod_time, mod_date) = if let Some(last_modified) = &self.opts.last_modified {
+            crate::spec::date::chrono_to_zip_time(last_modified)
+        } else {
+            crate::spec::date::chrono_to_zip_time(&Utc::now())
+        };
 
         let lf_header = LocalFileHeader {
             compressed_size: compressed_data.len() as u32,

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -54,6 +54,7 @@ pub(crate) mod compressed_writer;
 pub(crate) mod entry_stream;
 pub(crate) mod entry_whole;
 
+use chrono::{DateTime, Utc};
 pub use entry_stream::EntryStreamWriter;
 
 use crate::error::Result;
@@ -68,6 +69,7 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 pub struct EntryOptions {
     pub(crate) filename: String,
     pub(crate) compression: Compression,
+    pub(crate) last_modified: Option<DateTime<Utc>>,
     extra: Vec<u8>,
     comment: String,
     unix_permissions: u32,
@@ -76,7 +78,20 @@ pub struct EntryOptions {
 impl EntryOptions {
     /// Construct a new set of options from its required constituents.
     pub fn new(filename: String, compression: Compression) -> Self {
-        EntryOptions { filename, compression, extra: Vec::new(), comment: String::new(), unix_permissions: 0 }
+        EntryOptions {
+            filename,
+            compression,
+            last_modified: None,
+            extra: Vec::new(),
+            comment: String::new(),
+            unix_permissions: 0,
+        }
+    }
+
+    /// Consume the options and override the last modified timestamp.
+    pub fn last_modified(mut self, last_modified: DateTime<Utc>) -> Self {
+        self.last_modified = Some(last_modified);
+        self
     }
 
     /// Consume the options and override the extra field data.


### PR DESCRIPTION
I have a use case where I need to create ZIP files that are byte-identical when fed the same files. That's not currently possible with this library since the modification time on entries is always set from `Utc::now`.

This PR adds a new builder method to `EntryOptions` for setting a specific time. The method is named `last_modified` to match the corresponding getter on `ZipEntry`.

Let me know if you have any concerns or would like anything adjusted.