### PR TITLE
fix bug in hour conversion of modified time

### DIFF
--- a/src/spec/date.rs
+++ b/src/spec/date.rs
@@ -11,7 +11,7 @@ pub fn zip_date_to_chrono(date: u16, time: u16) -> DateTime<Utc> {
     let months = ((date & 0x1E0) >> 5).into();
     let days = (date & 0x1F).into();
 
-    let hours = ((time & 0x1F) >> 11).into();
+    let hours = ((time & 0xF800) >> 11).into();
     let mins = ((time & 0x7E0) >> 5).into();
     let secs = ((time & 0x1F) << 1).into();
 
@@ -30,9 +30,22 @@ pub fn chrono_to_zip_time(dt: &DateTime<Utc>) -> (u16, u16) {
     let month: u16 = ((dt.date().month() << 5) & 0x1E0).try_into().unwrap();
     let day: u16 = (dt.date().day() & 0x1F).try_into().unwrap();
 
-    let hour: u16 = ((dt.time().hour() << 11) & 0x1F).try_into().unwrap();
+    let hour: u16 = ((dt.time().hour() << 11) & 0xF800 ).try_into().unwrap();
     let min: u16 = ((dt.time().minute() << 5) & 0x7E0).try_into().unwrap();
     let second: u16 = ((dt.time().second() >> 1) & 0x1F).try_into().unwrap();
 
     (hour | min | second, year | month | day)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    #[test]
+    fn date_conversion_test() { 
+        let original_dt = Utc.timestamp(1666544102, 0);
+        let (time, date) = chrono_to_zip_time(&original_dt);
+        let result_dt = zip_date_to_chrono(date, time);
+        assert_eq!(result_dt, original_dt);
+    }
 }


### PR DESCRIPTION
The current code always sets hour to 0