### PR TITLE
Remove unused features from time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ xz = ["async-compression/xz"]
 async-compression = { version = "0.3.15", default-features = false, features = ["tokio"] }
 async_io_utilities = { git = "https://github.com/Majored/rs-async-io-utilities" }
 tokio = { version = "1.21.2", features = ["io-util", "fs"] }
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 crc32fast = "1.3.2"
 thiserror = "1.0.37"
 


### PR DESCRIPTION
This also removes a dependency on time 0.1.x which has a open RUSTSEC advisory.