### PR TITLE
Make it possible to set the compression level used.

### DIFF
--- a/src/entry/builder.rs
+++ b/src/entry/builder.rs
@@ -9,6 +9,8 @@ use crate::entry::ZipEntry;
 #[cfg(doc)]
 use crate::entry::ext::ZipEntryBuilderExt;
 
+use super::CompressionLevel;
+
 /// A builder for [`ZipEntry`].
 /// 
 /// As with the built type, this builder is intended to solely provide access to the raw underlying data. Any
@@ -27,6 +29,15 @@ impl ZipEntryBuilder {
     /// A filename and compression method are needed to construct the builder as minimal parameters.
     pub fn new(filename: String, compression: Compression) -> Self {
         Self(ZipEntry::new(filename, compression))
+    }
+
+    /// Set the compression level.
+    ///
+    /// What the precise value means is implementation defined so it
+    /// depends on what compression algorithm is used.
+    pub fn set_compression_level(mut self, level: CompressionLevel) -> Self {
+	self.0.compression_level = level.into_level();
+	self
     }
 
     /// Sets the entry's attribute host compatibility.

--- a/src/entry/level.rs
+++ b/src/entry/level.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use async_compression::Level;
+
+// Developer note: This is a copy of async_compression::Level to hide
+// implementation details and allow easier updates.
+
+/// Level of compression data should be compressed with.
+#[derive(Debug, Clone, Copy)]
+pub enum CompressionLevel {
+    /// Fastest quality of compression, usually produces bigger size.
+    Fastest,
+    /// Best quality of compression, usually produces the smallest size.
+    Best,
+    /// Default quality of compression defined by the selected compression algorithm.
+    Default,
+    /// Precise quality based on the underlying compression algorithms'
+    /// qualities. The interpretation of this depends on the algorithm chosen
+    /// and the specific implementation backing it.
+    /// Qualities are implicitly clamped to the algorithm's maximum.
+    Precise(u32),
+}
+
+impl CompressionLevel {
+    pub(crate) fn into_level(self) -> Level {
+	match self {
+	    CompressionLevel::Fastest => Level::Fastest,
+	    CompressionLevel::Best => Level::Best,
+	    CompressionLevel::Default => Level::Default,
+	    CompressionLevel::Precise(n) => Level::Precise(n),
+	}
+    }
+}

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+mod level;
+pub use level::CompressionLevel;
+
 pub mod ext;
 pub mod builder;
 
@@ -24,6 +27,7 @@ use crate::entry::ext::ZipEntryExt;
 pub struct ZipEntry {
     pub(crate) filename: String,
     pub(crate) compression: Compression,
+    pub(crate) compression_level: async_compression::Level,
     pub(crate) crc32: u32,
     pub(crate) uncompressed_size: u32,
     pub(crate) compressed_size: u32,
@@ -46,6 +50,7 @@ impl ZipEntry {
         ZipEntry {
             filename,
             compression,
+            compression_level: async_compression::Level::Default,
             crc32: 0,
             uncompressed_size: 0,
             compressed_size: 0,

--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -145,6 +145,7 @@ pub(crate) async fn read_cd_entry<R: AsyncRead + Unpin>(reader: &mut R) -> Resul
     let entry = ZipEntry {
         filename,
         compression,
+        compression_level: async_compression::Level::Default,
         attribute_compatibility: AttributeCompatibility::Unix, /// FIXME: Default to Unix for the moment
         crc32: header.crc,
         uncompressed_size: header.uncompressed_size,

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -108,6 +108,7 @@ pub(crate) async fn read_lfh<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Opt
     let entry = ZipEntry {
         filename,
         compression,
+        compression_level: async_compression::Level::Default,
         attribute_compatibility: AttributeCompatibility::Unix,
         crc32: header.crc,
         uncompressed_size: header.uncompressed_size,


### PR DESCRIPTION
This has a copy of the `async_compression::Level` enum so it can be updated without breaking the public api.