### PR TITLE
Add specific level back and make it possible to access the inner writer.

### DIFF
--- a/src/spec/compression.rs
+++ b/src/spec/compression.rs
@@ -84,13 +84,19 @@ pub enum DeflateOption {
 
     // Super Fast (-es) compression option was used.
     Super,
+
+    /// Other implementation defined level.
+    Other(u32),
 }
 
 impl DeflateOption {
     pub(crate) fn into_level(self) -> Level {
         // FIXME: There's no clear documentation on what these specific levels defined in the ZIP specification relate
         // to. We want to be compatible with any other library, and not specific to `async_compression`'s levels.
-
-        Level::Default
+	if let Self::Other(l) = self {
+	    Level::Precise(l)
+	} else {
+            Level::Default
+	}
     }
 }

--- a/src/write/io/offset.rs
+++ b/src/write/io/offset.rs
@@ -40,6 +40,10 @@ where
     pub fn into_inner(self) -> W {
         self.inner
     }
+
+    pub fn inner_mut(&mut self) -> &mut W {
+	&mut self.inner
+    }
 }
 
 impl<W> AsyncWrite for AsyncOffsetWriter<W>

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -101,6 +101,10 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
         self.comment_opt = Some(comment);
     }
 
+    pub fn inner_mut(&mut self) -> &mut W {
+	self.writer.inner_mut()
+    }
+
     /// Consumes this ZIP writer and completes all closing tasks.
     ///
     /// This includes:
@@ -109,7 +113,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
     /// - Writing the file comment.
     ///
     /// Failiure to call this function before going out of scope would result in a corrupted ZIP file.
-    pub async fn close(mut self) -> Result<()> {
+    pub async fn close(mut self) -> Result<W> {
         let cd_offset = self.writer.offset();
 
         for entry in &self.cd_entries {
@@ -136,6 +140,6 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
             self.writer.write_all(comment.as_bytes()).await?;
         }
 
-        Ok(())
+        Ok(self.writer.into_inner())
     }
 }


### PR DESCRIPTION
The implementation defined levels was made impossible to access directly, I am not sure if you want that specifically since you seen to go a lot up against the draft standard.

Access of the inner writer allows things like swapping out a vec or similar.