### PR TITLE
feat: fix issues and enable querying file position

### DIFF
--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -6,6 +6,7 @@ pub mod builder;
 use crate::entry::builder::ZipEntryBuilder;
 use crate::spec::attribute::AttributeCompatibility;
 use crate::spec::compression::Compression;
+use crate::spec::consts::{LFH_LENGTH, SIGNATURE_LENGTH};
 use crate::spec::header::GeneralPurposeFlag;
 use chrono::{DateTime, Utc};
 
@@ -137,4 +138,25 @@ impl ZipEntry {
 pub(crate) struct ZipEntryMeta {
     pub(crate) general_purpose_flag: GeneralPurposeFlag,
     pub(crate) file_offset: u64,
+}
+
+/// Stores information about a Zip entry inside of an archive. Besides storing archive independant
+/// information like the size and timestamp it can also be used to query information about how the
+/// entry is stored in an archive.
+#[derive(Clone)]
+pub struct StoredZipEntry {
+    pub entry: ZipEntry,
+    pub(crate) meta: ZipEntryMeta,
+}
+
+impl StoredZipEntry {
+    /// Returns the offset in bytes from where the data of the entry starts.
+    pub fn data_offset(&self) -> u64 {
+        let header_length = SIGNATURE_LENGTH + LFH_LENGTH;
+        let trailing_length = self.entry.comment().as_bytes().len()
+            + self.entry.extra_field().len()
+            + self.entry.filename.as_bytes().len();
+
+        self.meta.file_offset + (header_length as u64) + (trailing_length as u64)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,4 +30,6 @@ pub enum ZipError {
     CRC32CheckError,
     #[error("entry index was out of bounds")]
     EntryIndexOutOfBounds,
+    #[error("Encountered an unexpected header (actual: {0:#x}, expected: {1:#x}).")]
+    UnexpectedHeaderError(u32, u32),
 }

--- a/src/file/builder.rs
+++ b/src/file/builder.rs
@@ -14,7 +14,7 @@ impl From<ZipFile> for ZipFileBuilder {
 
 impl Default for ZipFileBuilder {
     fn default() -> Self {
-        ZipFileBuilder(ZipFile { entries: Vec::new(), metas: Vec::new(), zip64: false, comment: String::new() })
+        ZipFileBuilder(ZipFile { entries: Vec::new(), zip64: false, comment: String::new() })
     }
 }
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -3,15 +3,13 @@
 
 pub(crate) mod builder;
 
-use crate::entry::{ZipEntry, ZipEntryMeta};
+use crate::entry::StoredZipEntry;
 use builder::ZipFileBuilder;
 
 /// An immutable store of data about a ZIP file.
 #[derive(Clone)]
 pub struct ZipFile {
-    pub(crate) entries: Vec<ZipEntry>,
-    #[allow(dead_code)]
-    pub(crate) metas: Vec<ZipEntryMeta>,
+    pub(crate) entries: Vec<StoredZipEntry>,
     pub(crate) zip64: bool,
     pub(crate) comment: String,
 }
@@ -24,7 +22,7 @@ impl From<ZipFileBuilder> for ZipFile {
 
 impl ZipFile {
     /// Returns a list of this ZIP file's entries.
-    pub fn entries(&self) -> &[ZipEntry] {
+    pub fn entries(&self) -> &[StoredZipEntry] {
         &self.entries
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod write;
 pub(crate) mod entry;
 pub(crate) mod file;
 pub(crate) mod spec;
+pub(crate) mod utils;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/src/read/io/locator.rs
+++ b/src/read/io/locator.rs
@@ -57,7 +57,7 @@ where
         let read = reader.read(&mut buffer).await?;
 
         if let Some(match_index) = reverse_search_buffer(&buffer[..read], signature) {
-            return Ok(position + ((match_index + 1) - SIGNATURE_LENGTH) as u64);
+            return Ok(position + (match_index + 1) as u64);
         }
 
         // If we hit the start of the data or the lower bound, we're unable to locate the EOCDR.

--- a/src/spec/date.rs
+++ b/src/spec/date.rs
@@ -15,20 +15,17 @@ pub fn zip_date_to_chrono(date: u16, time: u16) -> DateTime<Utc> {
     let mins = ((time & 0x7E0) >> 5).into();
     let secs = ((time & 0x1F) << 1).into();
 
-    match Utc.ymd_opt(years, months, days) {
-        chrono::LocalResult::Single(t) => match t.and_hms_opt(hours, mins, secs) {
-            Some(dt) => dt,
-            None => chrono::DateTime::<chrono::Utc>::MIN_UTC,
-        },
+    match Utc.with_ymd_and_hms(years, months, days, hours, mins, secs) {
+        chrono::LocalResult::Single(dt) => dt,
         _ => chrono::DateTime::<chrono::Utc>::MIN_UTC,
     }
 }
 
 // Converts a `chrono` structure into a date and time stored in ZIP headers.
 pub fn chrono_to_zip_time(dt: &DateTime<Utc>) -> (u16, u16) {
-    let year: u16 = (((dt.date().year() - 1980) << 9) & 0xFE00).try_into().unwrap();
-    let month: u16 = ((dt.date().month() << 5) & 0x1E0).try_into().unwrap();
-    let day: u16 = (dt.date().day() & 0x1F).try_into().unwrap();
+    let year: u16 = (((dt.date_naive().year() - 1980) << 9) & 0xFE00).try_into().unwrap();
+    let month: u16 = ((dt.date_naive().month() << 5) & 0x1E0).try_into().unwrap();
+    let day: u16 = (dt.date_naive().day() & 0x1F).try_into().unwrap();
 
     let hour: u16 = ((dt.time().hour() << 11) & 0xF800).try_into().unwrap();
     let min: u16 = ((dt.time().minute() << 5) & 0x7E0).try_into().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+use crate::error::{Result, ZipError};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+// Assert that the next four-byte signature read by a reader which impls AsyncRead matches the expected signature.
+pub(crate) async fn assert_signature<R: AsyncRead + Unpin>(reader: &mut R, expected: u32) -> Result<()> {
+    match reader.read_u32_le().await? {
+        actual if actual == expected => Ok(()),
+        actual => Err(ZipError::UnexpectedHeaderError(actual, expected)),
+    }
+}


### PR DESCRIPTION
Ive been working on querying information from a ZIP archive over HTTP with the use of range requests. To be able to do that correctly I needed access to the position of an entry in the zip archive as well as access to the underlying reader.

It look like the project is going through some major refactor which causes som errors as well. I did my best to fix any issues (like signatures no longer being read) as well as some deprecation warnings.

With these changes Im able to use the current `main` branch to query and extract zip archives.

Let me know what you think! Im currently using my fork but Id much rather get this merged!