### PR TITLE
Derive Clone for ZipFileReader

### DIFF
--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -31,6 +31,7 @@ use crate::read::io::entry::ZipEntryReader;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, SeekFrom};
 
 /// A ZIP reader which acts over a seekable source.
+#[derive(Clone)]
 pub struct ZipFileReader<R> {
     reader: R,
     file: ZipFile,


### PR DESCRIPTION
This PR makes it possible to clone a ZipFileReader (if the underlying reader can also be cloned)