### PR TITLE
Fix bug in file decompression

### DIFF
--- a/src/read/io/owned.rs
+++ b/src/read/io/owned.rs
@@ -5,16 +5,35 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use pin_project::pin_project;
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf};
 
 /// A wrapping reader which holds an owned R or a mutable borrow to R.
 ///
 /// This is used to represent whether the supplied reader can be acted on concurrently or not (with an owned value
 /// suggesting that R implements some method of synchronisation & cloning).
 #[pin_project(project = OwnedReaderProj)]
-pub(crate) enum OwnedReader<'a, R> {
-    Owned(#[pin] R),
-    Borrow(#[pin] &'a mut R),
+pub(crate) enum OwnedReader<'a, R: AsyncRead + Unpin> {
+    Owned(#[pin] BufReader<R>),
+    Borrow(#[pin] BufReader<&'a mut R>),
+}
+
+impl<'a, R> AsyncBufRead for OwnedReader<'a, R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
+        match self.project() {
+            OwnedReaderProj::Owned(inner) => inner.poll_fill_buf(cx),
+            OwnedReaderProj::Borrow(inner) => inner.poll_fill_buf(cx),
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        match self.project() {
+            OwnedReaderProj::Owned(inner) => inner.consume(amt),
+            OwnedReaderProj::Borrow(inner) => inner.consume(amt),
+        }
+    }
 }
 
 impl<'a, R> AsyncRead for OwnedReader<'a, R>


### PR DESCRIPTION
This PR fixes https://github.com/Majored/rs-async-zip/issues/54

This fix is implemented in a way where it shouldn't have an impact on the number of reads or seeks made to the underlying reader (vs the current code).

(It does this by sharing a `BufReader` between the `CompressedReader` and the code that skips the local file header + trailing data. Since the LFH + trailing data is usually significantly smaller than the buffer size, it shouldn't result in additional reads most of the time. See the issue linked above for more details)