### PR TITLE
#70: Find EOCDL directly

### DIFF
--- a/src/entry/builder.rs
+++ b/src/entry/builder.rs
@@ -2,10 +2,7 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use crate::entry::ZipEntry;
-use crate::spec::attribute::AttributeCompatibility;
-use crate::spec::compression::Compression;
-use crate::spec::date::ZipDateTime;
-use crate::spec::header::ExtraField;
+use crate::spec::{attribute::AttributeCompatibility, date::ZipDateTime, header::ExtraField, Compression};
 
 /// A builder for [`ZipEntry`].
 pub struct ZipEntryBuilder(pub(crate) ZipEntry);

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -7,11 +7,13 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
 use crate::entry::builder::ZipEntryBuilder;
 use crate::error::{Result, ZipError};
-use crate::spec::attribute::AttributeCompatibility;
-use crate::spec::compression::Compression;
-use crate::spec::consts::LFH_SIGNATURE;
-use crate::spec::date::ZipDateTime;
-use crate::spec::header::{ExtraField, LocalFileHeader};
+use crate::spec::{
+    attribute::AttributeCompatibility,
+    consts::LFH_SIGNATURE,
+    date::ZipDateTime,
+    header::{ExtraField, LocalFileHeader},
+    Compression,
+};
 
 /// An immutable store of data about a ZIP entry.
 ///

--- a/src/read/fs.rs
+++ b/src/read/fs.rs
@@ -73,11 +73,11 @@ use crate::read::seek;
 use crate::error::{Result, ZipError};
 use crate::file::ZipFile;
 use crate::read::io::entry::ZipEntryReader;
+use crate::ZipEntry;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::ZipEntry;
 use tokio::fs::File;
 use tokio::io::BufReader;
 

--- a/src/read/io/combined_record.rs
+++ b/src/read/io/combined_record.rs
@@ -36,10 +36,10 @@ impl CombinedCentralDirectoryRecord {
                 combined.num_entries_in_directory_on_disk = zip64eocdr.num_entries_in_directory_on_disk;
             }
             if eocdr.num_of_entries == u16::MAX {
-                combined.num_entries_in_directory = zip64eocdr.num_entries_in_directory_on_disk;
+                combined.num_entries_in_directory = zip64eocdr.num_entries_in_directory;
             }
             if eocdr.size_cent_dir == u32::MAX {
-                combined.directory_size = zip64eocdr.num_entries_in_directory_on_disk;
+                combined.directory_size = zip64eocdr.directory_size;
             }
             if eocdr.cent_dir_offset == u32::MAX {
                 combined.offset_of_start_of_directory = zip64eocdr.offset_of_start_of_directory;

--- a/src/read/io/compressed.rs
+++ b/src/read/io/compressed.rs
@@ -8,8 +8,6 @@ use std::task::{Context, Poll};
 
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
 use async_compression::tokio::bufread;
-#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
-use tokio::io::BufReader;
 
 use pin_project::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};

--- a/src/read/io/compressed.rs
+++ b/src/read/io/compressed.rs
@@ -1,14 +1,13 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use crate::spec::compression::Compression;
+use crate::spec::Compression;
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
 use async_compression::tokio::bufread;
-
 use pin_project::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
 

--- a/src/read/io/entry.rs
+++ b/src/read/io/entry.rs
@@ -4,7 +4,7 @@
 use crate::entry::ZipEntry;
 use crate::error::{Result, ZipError};
 use crate::read::io::{compressed::CompressedReader, hashed::HashedReader, owned::OwnedReader};
-use crate::spec::compression::Compression;
+use crate::spec::Compression;
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/read/io/mod.rs
+++ b/src/read/io/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod hashed;
 pub(crate) mod locator;
 pub(crate) mod owned;
 
+pub use combined_record::CombinedCentralDirectoryRecord;
+
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Read and return a dynamic length string from a reader which impls AsyncRead.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -12,22 +12,21 @@ pub mod fs;
 
 pub(crate) mod io;
 
-pub use crate::read::io::entry::ZipEntryReader;
-
 use crate::entry::{StoredZipEntry, ZipEntry};
 use crate::error::{Result, ZipError};
 use crate::file::ZipFile;
 use crate::spec::attribute::AttributeCompatibility;
-use crate::spec::compression::Compression;
 use crate::spec::consts::{CDH_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE, SIGNATURE_LENGTH, ZIP64_EOCDL_LENGTH};
 use crate::spec::date::ZipDateTime;
 use crate::spec::header::{
     CentralDirectoryRecord, EndOfCentralDirectoryHeader, ExtraField, LocalFileHeader,
     Zip64EndOfCentralDirectoryLocator, Zip64EndOfCentralDirectoryRecord, Zip64ExtendedInformationExtraField,
 };
+use crate::spec::Compression;
 
-use crate::read::io::combined_record::CombinedCentralDirectoryRecord;
+use crate::read::io::CombinedCentralDirectoryRecord;
 use crate::spec::parse::parse_extra_fields;
+
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, SeekFrom};
 
 /// The max buffer size used when parsing the central directory, equal to 20MiB.

--- a/src/spec/consts.rs
+++ b/src/spec/consts.rs
@@ -26,9 +26,9 @@ pub const EOCDR_LENGTH: usize = 18;
 /// The signature for the zip64 end of central directory locator.
 /// Ref: https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#4315
 pub const ZIP64_EOCDL_SIGNATURE: u32 = 0x07064b50;
-/// The length of the ZIP64 EOCDL, excluding the signature.
+/// The length of the ZIP64 EOCDL, including the signature.
 /// The EOCDL has a fixed size, thankfully.
-pub const ZIP64_EOCDL_LENGTH: usize = 16;
+pub const ZIP64_EOCDL_LENGTH: u64 = 20;
 
 /// The contents of a header field when one must reference the zip64 version instead.
 pub const NON_ZIP64_MAX_SIZE: u32 = 0xFFFFFFFF;

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -111,7 +111,7 @@ pub struct Zip64EndOfCentralDirectoryRecord {
 }
 
 // https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#4315
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Zip64EndOfCentralDirectoryLocator {
     pub number_of_disk_with_start_of_zip64_end_of_central_directory: u32,
     pub relative_offset: u64,

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -9,3 +9,5 @@ pub(crate) mod extra_field;
 pub(crate) mod header;
 pub(crate) mod parse;
 pub(crate) mod version;
+
+pub use compression::Compression;

--- a/src/spec/version.rs
+++ b/src/spec/version.rs
@@ -3,7 +3,7 @@
 
 use crate::entry::ZipEntry;
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
-use crate::spec::compression::Compression;
+use crate::spec::Compression;
 
 pub(crate) const SPEC_VERSION_MADE_BY: u16 = 63;
 

--- a/src/tests/read/compression/mod.rs
+++ b/src/tests/read/compression/mod.rs
@@ -2,7 +2,7 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use crate::read::io::compressed::CompressedReader;
-use crate::spec::compression::Compression;
+use crate::spec::Compression;
 
 compressed_test_helper!(stored_test, Compression::Stored, "foo bar", "foo bar");
 

--- a/src/tests/spec/date.rs
+++ b/src/tests/spec/date.rs
@@ -7,7 +7,7 @@ use chrono::{TimeZone, Utc};
 #[test]
 #[cfg(feature = "chrono")]
 fn date_conversion_test() {
-    let original_dt = Utc.timestamp(1666544102, 0);
+    let original_dt = Utc.timestamp_opt(1666544102, 0).unwrap();
     let zip_dt = crate::ZipDateTime::from_chrono(&original_dt);
     let result_dt = zip_dt.as_chrono().single().expect("expected single unique result");
     assert_eq!(result_dt, original_dt);

--- a/src/write/compressed_writer.rs
+++ b/src/write/compressed_writer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use crate::spec::compression::Compression;
+use crate::spec::Compression;
 use crate::write::io::offset::AsyncOffsetWriter;
 
 use std::io::Error;

--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -3,9 +3,11 @@
 
 use crate::entry::ZipEntry;
 use crate::error::Result;
-use crate::spec::compression::Compression;
-use crate::spec::extra_field::ExtraFieldAsBytes;
-use crate::spec::header::{CentralDirectoryRecord, GeneralPurposeFlag, LocalFileHeader};
+use crate::spec::{
+    extra_field::ExtraFieldAsBytes,
+    header::{CentralDirectoryRecord, GeneralPurposeFlag, LocalFileHeader},
+    Compression,
+};
 use crate::write::{CentralDirectoryEntry, ZipFileWriter};
 
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]


### PR DESCRIPTION
Find the Zip64 End Of Central Directory Locator immediately instead of doing a second seek.

Deleted the unnecessary locate record by signature function, effectively un-generalizing it.

Merge after PR #72 . Fixes Issue #70 