### PR TITLE
Zip64 Write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"], opti
 [dev-dependencies]
 # tests
 tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1.11"
 env_logger = "0.10.0"
 zip = "0.6.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"], opti
 [dev-dependencies]
 # tests
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1.11"
 env_logger = "0.10.0"
 zip = "0.6.3"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Harry
-Copyright (c) 2023 Cognite
+Copyright (c) 2023 Cognite AS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/entry/builder.rs
+++ b/src/entry/builder.rs
@@ -33,6 +33,15 @@ impl ZipEntryBuilder {
         self
     }
 
+    /// Set a size hint for the file, to be written into the local file header.
+    /// Unlikely to be useful except for the case of streaming files to be Store'd.
+    /// This size hint does not affect the central directory, nor does it affect whole files.
+    pub fn size<N: Into<u64>, M: Into<u64>>(mut self, compressed_size: N, uncompressed_size: M) -> Self {
+        self.0.compressed_size = compressed_size.into();
+        self.0.uncompressed_size = uncompressed_size.into();
+        self
+    }
+
     /// Set the deflate compression option.
     ///
     /// If the compression type isn't deflate, this option has no effect.

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 /// A Result type alias over ZipError to minimise repetition.
 pub type Result<V> = std::result::Result<V, ZipError>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Zip64ErrorCase {
     TooManyFiles,
     LargeFile,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,26 @@
 
 //! A module which holds relevant error reporting structures/types.
 
+use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
 /// A Result type alias over ZipError to minimise repetition.
 pub type Result<V> = std::result::Result<V, ZipError>;
+
+#[derive(Debug)]
+pub enum Zip64ErrorCase {
+    TooManyFiles,
+    LargeFile,
+}
+
+impl Display for Zip64ErrorCase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooManyFiles => write!(f, "More than 65536 files in archive"),
+            Self::LargeFile => write!(f, "File is larger than 4 GiB"),
+        }
+    }
+}
 
 /// An enum of possible errors and their descriptions.
 #[non_exhaustive]
@@ -20,6 +36,8 @@ pub enum ZipError {
     AttributeCompatibilityNotSupported(u16),
     #[error("attempted to read a ZIP64 file whilst on a 32-bit target")]
     TargetZip64NotSupported,
+    #[error("attempted to write a ZIP file with force_no_zip64 when ZIP64 is needed: {0}")]
+    Zip64Needed(Zip64ErrorCase),
     #[error("end of file has not been reached")]
     EOFNotReached,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,12 @@ pub enum ZipError {
     Zip64Needed(Zip64ErrorCase),
     #[error("end of file has not been reached")]
     EOFNotReached,
+    #[error("extra fields exceeded maximum size")]
+    ExtraFieldTooLarge,
+    #[error("comment exceeded maximum size")]
+    CommentTooLarge,
+    #[error("filename exceeded maximum size")]
+    FileNameTooLarge,
 
     #[error("unable to locate the end of central directory record")]
     UnableToLocateEOCDR,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -99,7 +99,7 @@ where
     Ok(entries)
 }
 
-fn get_zip64_extra_field(extra_fields: &[ExtraField]) -> Option<&Zip64ExtendedInformationExtraField> {
+pub(crate) fn get_zip64_extra_field(extra_fields: &[ExtraField]) -> Option<&Zip64ExtendedInformationExtraField> {
     for field in extra_fields {
         if let ExtraField::Zip64ExtendedInformationExtraField(zip64field) = field {
             return Some(zip64field);

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -108,6 +108,17 @@ pub(crate) fn get_zip64_extra_field(extra_fields: &[ExtraField]) -> Option<&Zip6
     None
 }
 
+pub(crate) fn get_zip64_extra_field_mut(
+    extra_fields: &mut [ExtraField],
+) -> Option<&mut Zip64ExtendedInformationExtraField> {
+    for field in extra_fields {
+        if let ExtraField::Zip64ExtendedInformationExtraField(zip64field) = field {
+            return Some(zip64field);
+        }
+    }
+    None
+}
+
 fn get_combined_sizes(
     uncompressed_size: u32,
     compressed_size: u32,

--- a/src/spec/consts.rs
+++ b/src/spec/consts.rs
@@ -23,6 +23,10 @@ pub const CDH_LENGTH: usize = 42;
 pub const EOCDR_SIGNATURE: u32 = 0x6054b50;
 /// The minimum length of the EOCDR, excluding the signature.
 pub const EOCDR_LENGTH: usize = 18;
+
+/// The signature for the zip64 end of central directory record.
+/// Ref: https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#4314
+pub const ZIP64_EOCDR_SIGNATURE: u32 = 0x06064b50;
 /// The signature for the zip64 end of central directory locator.
 /// Ref: https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#4315
 pub const ZIP64_EOCDL_SIGNATURE: u32 = 0x07064b50;

--- a/src/spec/consts.rs
+++ b/src/spec/consts.rs
@@ -32,6 +32,8 @@ pub const ZIP64_EOCDL_LENGTH: u64 = 20;
 
 /// The contents of a header field when one must reference the zip64 version instead.
 pub const NON_ZIP64_MAX_SIZE: u32 = 0xFFFFFFFF;
+/// The maximum number of files or disks in a ZIP file before it requires ZIP64.
+pub const NON_ZIP64_MAX_NUM_FILES: u16 = 0xFFFF;
 
 // https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#439
 pub const DATA_DESCRIPTOR_SIGNATURE: u32 = 0x8074b50;

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -213,6 +213,23 @@ impl Zip64EndOfCentralDirectoryRecord {
         reader.read_exact(&mut buffer).await?;
         Ok(Self::from(buffer))
     }
+
+    pub fn as_bytes(&self) -> [u8; 52] {
+        let mut array = [0; 52];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.size_of_zip64_end_of_cd_record.to_le_bytes());
+        array_push!(array, cursor, self.version_made_by.to_le_bytes());
+        array_push!(array, cursor, self.version_needed_to_extract.to_le_bytes());
+        array_push!(array, cursor, self.disk_number.to_le_bytes());
+        array_push!(array, cursor, self.disk_number_start_of_cd.to_le_bytes());
+        array_push!(array, cursor, self.num_entries_in_directory_on_disk.to_le_bytes());
+        array_push!(array, cursor, self.num_entries_in_directory.to_le_bytes());
+        array_push!(array, cursor, self.directory_size.to_le_bytes());
+        array_push!(array, cursor, self.offset_of_start_of_directory.to_le_bytes());
+
+        array
+    }
 }
 
 impl Zip64EndOfCentralDirectoryLocator {
@@ -228,6 +245,17 @@ impl Zip64EndOfCentralDirectoryLocator {
         let mut buffer: [u8; 16] = [0; 16];
         reader.read_exact(&mut buffer).await?;
         Ok(Some(Self::from(buffer)))
+    }
+
+    pub fn as_bytes(&self) -> [u8; 16] {
+        let mut array = [0; 16];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.number_of_disk_with_start_of_zip64_end_of_central_directory.to_le_bytes());
+        array_push!(array, cursor, self.relative_offset.to_le_bytes());
+        array_push!(array, cursor, self.total_number_of_disks.to_le_bytes());
+
+        array
     }
 }
 

--- a/src/tests/read/zip64/mod.rs
+++ b/src/tests/read/zip64/mod.rs
@@ -57,6 +57,7 @@ async fn test_read_zip64_archive_stream() {
 
 /// Generate an example file only if it doesn't exist already.
 /// The file is placed adjacent to this rs file.
+#[cfg(feature = "fs")]
 fn generate_zip64many_zip() -> PathBuf {
     use std::io::Write;
     use zip::write::FileOptions;

--- a/src/tests/read/zip64/mod.rs
+++ b/src/tests/read/zip64/mod.rs
@@ -56,11 +56,11 @@ async fn test_read_zip64_archive_stream() {
 /// Generate an example file only if it doesn't exist already.
 /// The file is placed adjacent to this rs file.
 #[cfg(feature = "fs")]
-fn generate_zip64many_zip() -> PathBuf {
+fn generate_zip64many_zip() -> std::path::PathBuf {
     use std::io::Write;
     use zip::write::FileOptions;
 
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/tests/read/zip64/zip64many.zip");
 
     // Only recreate the zip if it doesnt already exist.

--- a/src/tests/read/zip64/mod.rs
+++ b/src/tests/read/zip64/mod.rs
@@ -2,8 +2,6 @@
 // Copyright (c) 2023 Cognite AS
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use std::path::PathBuf;
-
 use tokio::io::AsyncReadExt;
 
 use crate::tests::init_logger;

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -2,3 +2,4 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 pub(crate) mod offset;
+mod zip64;

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,5 +1,29 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncWrite;
+
 pub(crate) mod offset;
 mod zip64;
+
+/// /dev/null for AsyncWrite.
+/// Useful for tests that involve writing, but not reading, large amounts of data.
+pub(crate) struct AsyncSink;
+
+// AsyncSink is always ready to receive bytes and throw them away.
+impl AsyncWrite for AsyncSink {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -1,0 +1,63 @@
+// Copyright Cognite AS, 2023
+
+use crate::error::{Zip64ErrorCase, ZipError};
+use crate::spec::consts::NON_ZIP64_MAX_SIZE;
+use crate::tests::write::AsyncSink;
+use crate::write::ZipFileWriter;
+use crate::{Compression, ZipEntryBuilder};
+use tokio::io::AsyncWriteExt;
+
+#[tokio::test]
+async fn test_write_zip64_file() {}
+
+/// Tests that when force_no_zip64 is true, EntryWholeWriter errors when trying to write more than
+/// u16::MAX files to a single archive.
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_many_files_whole() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+    for i in 0..u16::MAX {
+        let entry = ZipEntryBuilder::new(format!("{i}"), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap()
+    }
+    let entry = ZipEntryBuilder::new(format!("65537"), Compression::Stored);
+    let result = writer.write_entry_whole(entry, &[]).await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+}
+
+/// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write more than
+/// u16::MAX files to a single archive.
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_many_files_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+    for i in 0..u16::MAX {
+        let entry = ZipEntryBuilder::new(format!("{i}"), Compression::Stored);
+        let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+        entrywriter.close().await.unwrap();
+    }
+    let entry = ZipEntryBuilder::new(format!("65537"), Compression::Stored);
+    let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+    let result = entrywriter.close().await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+}
+
+const NUM_BATCHES: usize = (NON_ZIP64_MAX_SIZE as u64 / 100_000 + 1) as usize;
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_large_file_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+
+    let entry = ZipEntryBuilder::new(format!("-"), Compression::Stored);
+    let mut entrywriter = writer.write_entry_stream(entry).await.unwrap();
+
+    // Writing 4GB, 1kb at a time
+    for _ in 0..NUM_BATCHES {
+        entrywriter.write_all(&[0; 100_000]).await.unwrap();
+    }
+    let result = entrywriter.close().await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile))));
+}

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -2,13 +2,98 @@
 
 use crate::error::{Zip64ErrorCase, ZipError};
 use crate::spec::consts::NON_ZIP64_MAX_SIZE;
+use crate::tests::init_logger;
 use crate::tests::write::AsyncSink;
 use crate::write::ZipFileWriter;
 use crate::{Compression, ZipEntryBuilder};
+use std::io::{Read, Write};
+
 use tokio::io::AsyncWriteExt;
 
+/// Test writing a small zip64 file. No zip64 extra fields would be emitted, but z64 end of directory
+/// records should be.
 #[tokio::test]
-async fn test_write_zip64_file() {}
+async fn test_write_zip64_file() {
+    init_logger();
+
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer).force_zip64();
+    let entry = ZipEntryBuilder::new("file1".to_string(), Compression::Stored);
+    writer.write_entry_whole(entry, &[0, 0, 0, 0]).await.unwrap();
+    let entry = ZipEntryBuilder::new("file2".to_string(), Compression::Stored);
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    entry_writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    let mut file1 = zip.by_name("file1").unwrap();
+    assert_eq!(file1.extra_data(), vec![]);
+    let mut buffer = Vec::new();
+    file1.read_to_end(&mut buffer).unwrap();
+    assert_eq!(buffer.as_slice(), &[0, 0, 0, 0]);
+    drop(file1);
+
+    let mut file2 = zip.by_name("file2").unwrap();
+    assert_eq!(file2.extra_data(), vec![]);
+    let mut buffer = Vec::new();
+    file2.read_to_end(&mut buffer).unwrap();
+    assert_eq!(buffer.as_slice(), &[0, 0, 0, 0]);
+}
+
+/// Test writing a zip64 file with more than u16::MAX files.
+#[tokio::test]
+async fn test_write_zip64_file_many_entries() {
+    init_logger();
+
+    // The generated file will likely be ~3MB in size.
+    let mut buffer = Vec::with_capacity(3_500_000);
+
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(i.to_string(), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap();
+    }
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    assert_eq!(zip.len(), u16::MAX as usize + 2);
+
+    for i in 0..=u16::MAX as u32 + 1 {
+        zip.by_name(&i.to_string()).unwrap();
+    }
+}
+
+/// Tests that EntryWholeWriter switches to Zip64 mode when writing too many files for a non-Zip64.
+#[tokio::test]
+async fn test_zip64_when_many_files_whole() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(format!("{i}"), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap()
+    }
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+}
+
+/// Tests that EntryStreamWriter switches to Zip64 mode when writing too many files for a non-Zip64.
+#[tokio::test]
+async fn test_zip64_when_many_files_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(format!("{i}"), Compression::Stored);
+        let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+        entrywriter.close().await.unwrap();
+    }
+
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+}
 
 /// Tests that when force_no_zip64 is true, EntryWholeWriter errors when trying to write more than
 /// u16::MAX files to a single archive.
@@ -45,6 +130,8 @@ async fn test_force_no_zip64_errors_with_too_many_files_stream() {
 }
 
 const NUM_BATCHES: usize = (NON_ZIP64_MAX_SIZE as u64 / 100_000 + 1) as usize;
+/// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write
+/// a file larger than ~4 GiB to an archive.
 #[tokio::test]
 async fn test_force_no_zip64_errors_with_too_large_file_stream() {
     let mut sink = AsyncSink;

--- a/src/write/entry_stream.rs
+++ b/src/write/entry_stream.rs
@@ -189,11 +189,16 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
 
         self.cd_entries.push(CentralDirectoryEntry { header: cdh, entry: self.entry });
         // Ensure that we can fit this many files in this archive if forcing no zip64
-        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize && self.force_no_zip64 {
-            Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))
-        } else {
-            Ok(())
+        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
+            if self.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+            }
+            if !*self.is_zip64 {
+                *self.is_zip64 = true;
+            }
         }
+
+        Ok(())
     }
 }
 

--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -45,8 +45,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             }
         };
 
-        let (lfh_compressed_size, lfh_uncompressed_size) =
-        if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
+        let (lfh_compressed_size, lfh_uncompressed_size) = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
             || compressed_data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
         {
             if self.writer.force_no_zip64 {

--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -113,11 +113,16 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
 
         self.writer.cd_entries.push(CentralDirectoryEntry { header, entry: self.entry });
         // Ensure that we can fit this many files in this archive if forcing no zip64
-        if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize && self.writer.force_no_zip64 {
-            Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))
-        } else {
-            Ok(())
+        if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
         }
+
+        Ok(())
     }
 }
 

--- a/src/write/entry_whole.rs
+++ b/src/write/entry_whole.rs
@@ -74,7 +74,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             uncompressed_size: lfh_uncompressed_size,
             compression: self.entry.compression().into(),
             crc: compute_crc(self.data),
-            extra_field_length: self.entry.extra_fields().len() as u16,
+            extra_field_length: self.entry.extra_fields().count_bytes() as u16,
             file_name_length: self.entry.filename().as_bytes().len() as u16,
             mod_time: self.entry.last_modification_date().time,
             mod_date: self.entry.last_modification_date().date,

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -186,7 +186,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
                 num_entries_in_directory_on_disk: num_entries_in_directory,
                 num_entries_in_directory,
                 directory_size: central_directory_size,
-                offset_of_start_of_directory: cd_offset as u64,
+                offset_of_start_of_directory: cd_offset,
             };
             self.writer.write_all(&crate::spec::consts::ZIP64_EOCDR_SIGNATURE.to_le_bytes()).await?;
             self.writer.write_all(&eocdr.as_bytes()).await?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -60,12 +60,15 @@ pub use entry_stream::EntryStreamWriter;
 use crate::entry::ZipEntry;
 use crate::error::Result;
 use crate::spec::extra_field::ExtraFieldAsBytes;
-use crate::spec::header::{CentralDirectoryRecord, EndOfCentralDirectoryHeader, Zip64EndOfCentralDirectoryLocator, Zip64EndOfCentralDirectoryRecord};
+use crate::spec::header::{
+    CentralDirectoryRecord, EndOfCentralDirectoryHeader, Zip64EndOfCentralDirectoryLocator,
+    Zip64EndOfCentralDirectoryRecord,
+};
 use entry_whole::EntryWholeWriter;
 use io::offset::AsyncOffsetWriter;
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 pub(crate) struct CentralDirectoryEntry {
     pub header: CentralDirectoryRecord,
@@ -165,11 +168,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
             num_entries_in_directory as u16
         };
         let cd_offset = cd_offset as u64;
-        let cd_offset_u32 = if cd_offset > NON_ZIP64_MAX_SIZE as u64 {
-            NON_ZIP64_MAX_SIZE
-        } else {
-            cd_offset as u32
-        };
+        let cd_offset_u32 = if cd_offset > NON_ZIP64_MAX_SIZE as u64 { NON_ZIP64_MAX_SIZE } else { cd_offset as u32 };
 
         // Add the zip64 EOCDR and EOCDL if we are in zip64 mode.
         if self.is_zip64 {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -121,6 +121,8 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
     }
 
     /// Write an entry of unknown size and data via streaming (ie. using a data descriptor).
+    /// The generated Local File Header will be invalid, with no compressed size, uncompressed size,
+    /// and a null CRC. This might cause problems with the destination reader.
     pub async fn write_entry_stream<E: Into<ZipEntry>>(&mut self, entry: E) -> Result<EntryStreamWriter<'_, W>> {
         EntryStreamWriter::from_raw(self, entry.into()).await
     }

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -60,11 +60,12 @@ pub use entry_stream::EntryStreamWriter;
 use crate::entry::ZipEntry;
 use crate::error::Result;
 use crate::spec::extra_field::ExtraFieldAsBytes;
-use crate::spec::header::{CentralDirectoryRecord, EndOfCentralDirectoryHeader};
+use crate::spec::header::{CentralDirectoryRecord, EndOfCentralDirectoryHeader, Zip64EndOfCentralDirectoryLocator, Zip64EndOfCentralDirectoryRecord};
 use entry_whole::EntryWholeWriter;
 use io::offset::AsyncOffsetWriter;
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
+use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
 
 pub(crate) struct CentralDirectoryEntry {
     pub header: CentralDirectoryRecord,
@@ -78,13 +79,36 @@ pub(crate) struct CentralDirectoryEntry {
 pub struct ZipFileWriter<W: AsyncWrite + Unpin> {
     pub(crate) writer: AsyncOffsetWriter<W>,
     pub(crate) cd_entries: Vec<CentralDirectoryEntry>,
+    /// If true, will error if a Zip64 struct must be written.
+    force_no_zip64: bool,
+    /// Whether to write Zip64 end of directory structs.
+    is_zip64: bool,
     comment_opt: Option<String>,
 }
 
 impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
     /// Construct a new ZIP file writer from a mutable reference to a writer.
     pub fn new(writer: W) -> Self {
-        Self { writer: AsyncOffsetWriter::new(writer), cd_entries: Vec::new(), comment_opt: None }
+        Self {
+            writer: AsyncOffsetWriter::new(writer),
+            cd_entries: Vec::new(),
+            comment_opt: None,
+            is_zip64: false,
+            force_no_zip64: false,
+        }
+    }
+
+    /// Force the ZIP writer to operate in non-ZIP64 mode.
+    /// If any files would need ZIP64, an error will be raised.
+    pub fn force_no_zip64(mut self) -> Self {
+        self.force_no_zip64 = true;
+        self
+    }
+
+    /// Force the ZIP writer to emit Zip64 structs.
+    pub fn force_zip64(mut self) -> Self {
+        self.is_zip64 = true;
+        self
     }
 
     /// Write a new ZIP entry of known size and data.
@@ -128,13 +152,59 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
             self.writer.write_all(entry.entry.comment().as_bytes()).await?;
         }
 
+        let central_directory_size = (self.writer.offset() - cd_offset) as u64;
+        let central_directory_size_u32 = if central_directory_size > NON_ZIP64_MAX_SIZE as u64 {
+            NON_ZIP64_MAX_SIZE
+        } else {
+            central_directory_size as u32
+        };
+        let num_entries_in_directory = self.cd_entries.len() as u64;
+        let num_entries_in_directory_u16 = if num_entries_in_directory > NON_ZIP64_MAX_NUM_FILES as u64 {
+            NON_ZIP64_MAX_NUM_FILES
+        } else {
+            num_entries_in_directory as u16
+        };
+        let cd_offset = cd_offset as u64;
+        let cd_offset_u32 = if cd_offset > NON_ZIP64_MAX_SIZE as u64 {
+            NON_ZIP64_MAX_SIZE
+        } else {
+            cd_offset as u32
+        };
+
+        // Add the zip64 EOCDR and EOCDL if we are in zip64 mode.
+        if self.is_zip64 {
+            let eocdr_offset = self.writer.offset();
+
+            let eocdr = Zip64EndOfCentralDirectoryRecord {
+                size_of_zip64_end_of_cd_record: 44,
+                version_made_by: crate::spec::version::as_made_by(),
+                version_needed_to_extract: 46,
+                disk_number: 0,
+                disk_number_start_of_cd: 0,
+                num_entries_in_directory_on_disk: num_entries_in_directory,
+                num_entries_in_directory,
+                directory_size: central_directory_size,
+                offset_of_start_of_directory: cd_offset as u64,
+            };
+            self.writer.write_all(&crate::spec::consts::CDH_SIGNATURE.to_le_bytes()).await?;
+            self.writer.write_all(&eocdr.as_bytes()).await?;
+
+            let eocdl = Zip64EndOfCentralDirectoryLocator {
+                number_of_disk_with_start_of_zip64_end_of_central_directory: 0,
+                relative_offset: eocdr_offset as u64,
+                total_number_of_disks: 1,
+            };
+            self.writer.write_all(&crate::spec::consts::ZIP64_EOCDL_SIGNATURE.to_le_bytes()).await?;
+            self.writer.write_all(&eocdl.as_bytes()).await?;
+        }
+
         let header = EndOfCentralDirectoryHeader {
             disk_num: 0,
             start_cent_dir_disk: 0,
-            num_of_entries_disk: self.cd_entries.len() as u16,
-            num_of_entries: self.cd_entries.len() as u16,
-            size_cent_dir: (self.writer.offset() - cd_offset) as u32,
-            cent_dir_offset: cd_offset as u32,
+            num_of_entries_disk: num_entries_in_directory_u16,
+            num_of_entries: num_entries_in_directory_u16,
+            size_cent_dir: central_directory_size_u32,
+            cent_dir_offset: cd_offset_u32,
             file_comm_length: self.comment_opt.as_ref().map(|v| v.len() as u16).unwrap_or_default(),
         };
 


### PR DESCRIPTION
Zip64 Write support, with many caveats.

The main problem is, of course, that the Zip format is not strictly defined and also doesn't seem to support non-seekable writing all that well. These problems were present previously, too, but adding a reference test against another library just made them more visible.

* uncompressed_size and compressed_size in the Local File Header is either u32::MAX or 0, respectively for Zip64 mode and non-Zip64 mode. In the Zip64 Extra Field the sizes are also set to 0.
    * This means any readers which defer to the Local File Header will either read too many bytes or read none.
    * Our non-seekable reader will have to fall back to scanning until the next local file header.
* The crc is 0 in the Local File Header. Implementations that depend on the local file header's crc will erroneously report our files as corrupted. Rust`zip` and MacOS's `unzip` both do this.
* When using `entry_stream`, we err on the side of using Zip64 headers unless `force_no_zip_64` is enabled. This is allowed in the zip specification.

In short, no matter what we do, the `entry_stream` method will have an invalid crc in the Local File Header, and unless a size hint is used (`ZipEntryBuilder.size()`) the file sizes will also be invalid, but depending on how the consumer-side reads the zip file it might not be a problem.

A note about tests: Two of the tests require 4GB of space. Currently they keep the file as a single buffer in memory. Github's task runners have 7GB of RAM (and 15GB SSD) so they might succeed. We might want to explore some alternative that uses less space, though I'm not sure that's even possible. I also hope that any contributors have more than 4GB of free, contiguous RAM available when running these tests. 

This PR contains:
* Zip64 support for writers
* Tests
* Explicit errors rather than panics for too-large comments, filename, extra fields, and number of files in archive.