### PR TITLE
Add an into_inner() method on stream ZipFileReader

### DIFF
--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -88,6 +88,11 @@ where
 
         Ok(Some(ZipFileReader(Reading(reader, entry))))
     }
+
+    /// Consumes the `ZipFileReader` returning the original `reader`
+    pub async fn into_inner(self) -> R {
+        self.0 .0
+    }
 }
 
 impl<'a, R> ZipFileReader<Reading<'a, Take<R>>>


### PR DESCRIPTION
This is helpful, because the zip file reader does not necessarily consume the stream fully. For example, if we reach the end of the zip file contents, but the stream isn't complete, it can be helpful to be able to get the reader back to continue taking input. Even the reader implementation as is does not necessarily read the metadata at the end of the zipfile after the final file entry.