### PR TITLE
Decouple this package from tokio by using the I/O traits from futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ full = ["chrono", "fs", "deflate", "bzip2", "lzma", "zstd", "xz"]
 # All features that are compatible with WASM
 full-wasm = ["chrono", "deflate", "zstd"]
 
-fs = ["tokio/fs"]
+fs = ["tokio", "tokio-util"]
 
 deflate = ["async-compression/deflate"]
 bzip2 = ["async-compression/bzip2"]
@@ -31,17 +31,20 @@ all-features = true
 
 [dependencies]
 crc32fast = "1"
+futures-util = { version = "0.3", features = ["io"] }
 log = "0.4.17"
-thiserror = "1"
-tokio = { version = "1", features = ["io-util"] }
 pin-project = "1"
+thiserror = "1"
 
-async-compression = { version = "0.3", default-features = false, features = ["tokio"], optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true}
+async-compression = { version = "0.3", default-features = false, features = ["futures-io"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+tokio = { version = "1", default-features = false, features = ["fs"], optional = true }
+tokio-util = { version = "0.7", features = ["compat"], optional = true }
 
 [dev-dependencies]
 # tests
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 env_logger = "0.10.0"
 zip = "0.6.3"
 

--- a/examples/actix_multipart.rs
+++ b/examples/actix_multipart.rs
@@ -13,8 +13,8 @@ mod inner {
     use actix_web::{web, App, HttpServer, Responder, ResponseError, Result};
     use derive_more::{Display, Error};
     use futures::StreamExt;
+    use futures_util::io::AsyncWriteExt;
     use tokio::fs::File;
-    use tokio::io::AsyncWriteExt;
     use uuid::Uuid;
 
     const TMP_DIR: &str = "./tmp/";

--- a/examples/cli_compress.rs
+++ b/examples/cli_compress.rs
@@ -20,8 +20,8 @@ mod inner {
     use std::path::{Path, PathBuf};
 
     use anyhow::{anyhow, bail, Result};
+    use futures_util::io::AsyncReadExt;
     use tokio::fs::File;
-    use tokio::io::AsyncReadExt;
 
     async fn run() -> Result<()> {
         let mut args = std::env::args().skip(1);

--- a/src/read/io/entry.rs
+++ b/src/read/io/entry.rs
@@ -9,8 +9,8 @@ use crate::spec::Compression;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures_util::io::{AsyncRead, AsyncReadExt, BufReader, Take};
 use pin_project::pin_project;
-use tokio::io::{AsyncRead, AsyncReadExt, BufReader, ReadBuf, Take};
 
 /// A ZIP entry reader which may implement decompression.
 #[pin_project]
@@ -38,7 +38,7 @@ impl<'a, R> AsyncRead for ZipEntryReader<'a, R>
 where
     R: AsyncRead + Unpin,
 {
-    fn poll_read(self: Pin<&mut Self>, c: &mut Context<'_>, b: &mut ReadBuf<'_>) -> Poll<tokio::io::Result<()>> {
+    fn poll_read(self: Pin<&mut Self>, c: &mut Context<'_>, b: &mut [u8]) -> Poll<std::io::Result<usize>> {
         self.project().reader.poll_read(c, b)
     }
 }

--- a/src/read/io/locator.rs
+++ b/src/read/io/locator.rs
@@ -18,12 +18,12 @@
 //! of a better algorithm for this (and have tested/verified its performance).
 
 #[cfg(doc)]
-use tokio::io::BufReader;
+use futures_util::io::BufReader;
 
 use crate::error::{Result as ZipResult, ZipError};
 use crate::spec::consts::{EOCDR_LENGTH, EOCDR_SIGNATURE, SIGNATURE_LENGTH};
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
+use futures_util::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
 /// The buffer size used when locating the EOCDR, equal to 2KiB.
 const BUFFER_SIZE: usize = 2048;

--- a/src/read/io/mod.rs
+++ b/src/read/io/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod owned;
 
 pub use combined_record::CombinedCentralDirectoryRecord;
 
-use tokio::io::{AsyncRead, AsyncReadExt};
+use futures_util::io::{AsyncRead, AsyncReadExt};
 
 /// Read and return a dynamic length string from a reader which impls AsyncRead.
 pub(crate) async fn read_string<R: AsyncRead + Unpin>(reader: R, length: usize) -> std::io::Result<String> {

--- a/src/read/io/owned.rs
+++ b/src/read/io/owned.rs
@@ -4,8 +4,8 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures_util::io::{AsyncBufRead, AsyncRead, BufReader};
 use pin_project::pin_project;
-use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf};
 
 /// A wrapping reader which holds an owned R or a mutable borrow to R.
 ///
@@ -53,7 +53,7 @@ impl<'a, R> AsyncRead for OwnedReader<'a, R>
 where
     R: AsyncRead + Unpin,
 {
-    fn poll_read(self: Pin<&mut Self>, c: &mut Context<'_>, b: &mut ReadBuf<'_>) -> Poll<tokio::io::Result<()>> {
+    fn poll_read(self: Pin<&mut Self>, c: &mut Context<'_>, b: &mut [u8]) -> Poll<std::io::Result<usize>> {
         match self.project() {
             OwnedReaderProj::Owned(inner) => inner.poll_read(c, b),
             OwnedReaderProj::Borrow(inner) => inner.poll_read(c, b),

--- a/src/read/mem.rs
+++ b/src/read/mem.rs
@@ -17,7 +17,7 @@
 //! ```no_run
 //! # use async_zip::read::mem::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use tokio::io::AsyncReadExt;
+//! # use futures_util::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new(Vec::new()).await?;
@@ -43,7 +43,7 @@
 //! ```no_run
 //! # use async_zip::read::mem::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use tokio::io::AsyncReadExt;
+//! # use futures_util::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new(Vec::new()).await?;
@@ -74,10 +74,9 @@ use crate::error::{Result, ZipError};
 use crate::file::ZipFile;
 use crate::read::io::entry::ZipEntryReader;
 
-use std::io::Cursor;
 use std::sync::Arc;
 
-use tokio::io::BufReader;
+use futures_util::io::{BufReader, Cursor};
 
 struct Inner {
     data: Vec<u8>,

--- a/src/read/seek.rs
+++ b/src/read/seek.rs
@@ -7,12 +7,13 @@
 //! ```no_run
 //! # use async_zip::read::seek::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use tokio::io::AsyncReadExt;
+//! # use futures_util::io::AsyncReadExt;
 //! # use tokio::fs::File;
+//! # use tokio_util::compat::TokioAsyncReadCompatExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let mut data = File::open("./foo.zip").await?;
-//!     let mut reader = ZipFileReader::new(&mut data).await?;
+//!     let mut reader = ZipFileReader::new(data.compat()).await?;
 //!
 //!     let mut data = Vec::new();
 //!     let mut entry = reader.entry(0).await?;
@@ -28,7 +29,7 @@ use crate::error::{Result, ZipError};
 use crate::file::ZipFile;
 use crate::read::io::entry::ZipEntryReader;
 
-use tokio::io::{AsyncRead, AsyncSeek, BufReader};
+use futures_util::io::{AsyncRead, AsyncSeek, BufReader};
 
 /// A ZIP reader which acts over a seekable source.
 #[derive(Clone)]
@@ -60,7 +61,7 @@ where
     }
 
     /// Returns a mutable reference to the inner seekable source.
-    /// 
+    ///
     /// Swapping the source (eg. via std::mem operations) may lead to inaccurate parsing.
     pub fn inner_mut(&mut self) -> &mut R {
         &mut self.reader

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -29,7 +29,7 @@
 //!
 //! # Example
 //! ```no_run
-//! # use std::io::Cursor;
+//! # use futures_util::io::Cursor;
 //! # use async_zip::error::Result;
 //! # use async_zip::read::stream::ZipFileReader;
 //! #
@@ -51,9 +51,9 @@ use crate::error::Result;
 use crate::error::ZipError;
 use crate::read::io::entry::ZipEntryReader;
 
-use tokio::io::AsyncReadExt;
-use tokio::io::Take;
-use tokio::io::{AsyncRead, BufReader};
+use futures_util::io::AsyncReadExt;
+use futures_util::io::Take;
+use futures_util::io::{AsyncRead, BufReader};
 
 /// A type which encodes that [`ZipFileReader`] is ready to open a new entry.
 pub struct Ready<R>(R);

--- a/src/tests/read/compression/mod.rs
+++ b/src/tests/read/compression/mod.rs
@@ -27,8 +27,7 @@ macro_rules! compressed_test_helper {
         #[cfg(test)]
         #[tokio::test]
         async fn $name() {
-            use std::io::Cursor;
-            use tokio::io::AsyncReadExt;
+            use futures_util::io::{AsyncReadExt, Cursor};
 
             let data = $data;
             let data_raw = $data_raw;

--- a/src/tests/read/locator/mod.rs
+++ b/src/tests/read/locator/mod.rs
@@ -29,7 +29,7 @@ fn search_two_byte_test() {
 
 #[tokio::test]
 async fn locator_empty_test() {
-    use std::io::Cursor;
+    use futures_util::io::Cursor;
 
     let data = &include_bytes!("empty.zip");
     let mut cursor = Cursor::new(data);
@@ -41,7 +41,7 @@ async fn locator_empty_test() {
 
 #[tokio::test]
 async fn locator_empty_max_comment_test() {
-    use std::io::Cursor;
+    use futures_util::io::Cursor;
 
     let data = &include_bytes!("empty-with-max-comment.zip");
     let mut cursor = Cursor::new(data);
@@ -53,7 +53,7 @@ async fn locator_empty_max_comment_test() {
 
 #[tokio::test]
 async fn locator_buffer_boundary_test() {
-    use std::io::Cursor;
+    use futures_util::io::Cursor;
 
     let data = &include_bytes!("empty-buffer-boundary.zip");
     let mut cursor = Cursor::new(data);

--- a/src/tests/read/zip64/mod.rs
+++ b/src/tests/read/zip64/mod.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023 Cognite AS
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use tokio::io::AsyncReadExt;
+use futures_util::io::AsyncReadExt;
 
 use crate::tests::init_logger;
 

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+use futures_util::io::AsyncWrite;
 use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::AsyncWrite;
 
 pub(crate) mod offset;
 mod zip64;
@@ -23,7 +23,7 @@ impl AsyncWrite for AsyncSink {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/src/tests/write/offset/mod.rs
+++ b/src/tests/write/offset/mod.rs
@@ -5,8 +5,8 @@ use crate::write::io::offset::AsyncOffsetWriter;
 
 #[tokio::test]
 async fn basic() {
-    use std::io::Cursor;
-    use tokio::io::AsyncWriteExt;
+    use futures_util::io::AsyncWriteExt;
+    use futures_util::io::Cursor;
 
     let mut writer = AsyncOffsetWriter::new(Cursor::new(Vec::new()));
     assert_eq!(writer.offset(), 0);

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -9,7 +9,7 @@ use crate::{Compression, ZipEntryBuilder};
 use std::io::Read;
 
 use crate::spec::header::ExtraField;
-use tokio::io::AsyncWriteExt;
+use futures_util::io::AsyncWriteExt;
 
 // Useful constants for writing a large file.
 const BATCH_SIZE: usize = 100_000;
@@ -100,7 +100,7 @@ async fn test_write_large_zip64_file() {
 /// Test writing a file, and reading it with async-zip
 #[tokio::test]
 async fn test_write_large_zip64_file_self_read() {
-    use tokio::io::AsyncReadExt;
+    use futures_util::io::AsyncReadExt;
 
     init_logger();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,16 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use crate::error::{Result, ZipError};
-use tokio::io::{AsyncRead, AsyncReadExt};
+use futures_util::io::{AsyncRead, AsyncReadExt};
 
 // Assert that the next four-byte signature read by a reader which impls AsyncRead matches the expected signature.
 pub(crate) async fn assert_signature<R: AsyncRead + Unpin>(reader: &mut R, expected: u32) -> Result<()> {
-    match reader.read_u32_le().await? {
+    let signature = {
+        let mut buffer = [0; 4];
+        reader.read_exact(&mut buffer).await?;
+        u32::from_le_bytes(buffer)
+    };
+    match signature {
         actual if actual == expected => Ok(()),
         actual => Err(ZipError::UnexpectedHeaderError(actual, expected)),
     }

--- a/src/write/io/offset.rs
+++ b/src/write/io/offset.rs
@@ -5,8 +5,8 @@ use std::io::{Error, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures_util::io::AsyncWrite;
 use pin_project::pin_project;
-use tokio::io::AsyncWrite;
 
 /// A wrapper around an [`AsyncWrite`] implementation which tracks the current byte offset.
 #[pin_project(project = OffsetWriterProj)]
@@ -62,8 +62,8 @@ where
         self.project().inner.poll_flush(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
-        self.project().inner.poll_shutdown(cx)
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        self.project().inner.poll_close(cx)
     }
 
     fn poll_write_vectored(
@@ -72,9 +72,5 @@ where
         bufs: &[IoSlice<'_>],
     ) -> Poll<Result<usize, Error>> {
         self.project().inner.poll_write_vectored(cx, bufs)
-    }
-
-    fn is_write_vectored(&self) -> bool {
-        self.inner.is_write_vectored()
     }
 }

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -11,10 +11,11 @@
 //! # use async_zip::{Compression, ZipEntryBuilder, write::ZipFileWriter};
 //! # use tokio::{fs::File, io::AsyncWriteExt};
 //! # use async_zip::error::ZipError;
+//! # use tokio_util::compat::TokioAsyncReadCompatExt;
 //! #
 //! # async fn run() -> Result<(), ZipError> {
 //! let mut file = File::create("foo.zip").await?;
-//! let mut writer = ZipFileWriter::new(&mut file);
+//! let mut writer = ZipFileWriter::new(file.compat());
 //!
 //! let data = b"This is an example file.";
 //! let opts = ZipEntryBuilder::new(String::from("foo.txt"), Compression::Deflate);
@@ -30,12 +31,14 @@
 //! # #[cfg(feature = "deflate")]
 //! # {
 //! # use async_zip::{Compression, ZipEntryBuilder, write::ZipFileWriter};
-//! # use tokio::{fs::File, io::AsyncWriteExt};
+//! # use tokio::fs::File;
 //! # use async_zip::error::ZipError;
+//! # use futures_util::io::AsyncWriteExt;
+//! # use tokio_util::compat::TokioAsyncWriteCompatExt;
 //! #
 //! # async fn run() -> Result<(), ZipError> {
 //! let mut file = File::create("foo.zip").await?;
-//! let mut writer = ZipFileWriter::new(&mut file);
+//! let mut writer = ZipFileWriter::new(file.compat_write());
 //!
 //! let data = b"This is an example file.";
 //! let opts = ZipEntryBuilder::new(String::from("bar.txt"), Compression::Deflate);

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -68,7 +68,7 @@ use entry_whole::EntryWholeWriter;
 use io::offset::AsyncOffsetWriter;
 
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use futures_util::io::{AsyncWrite, AsyncWriteExt};
 
 pub(crate) struct CentralDirectoryEntry {
     pub header: CentralDirectoryRecord,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,8 +6,9 @@ use async_zip::read::seek;
 use async_zip::write::ZipFileWriter;
 use async_zip::Compression;
 use async_zip::ZipEntryBuilder;
+use futures_util::io::AsyncWriteExt;
 use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 const FOLDER_PREFIX: &str = "tests/test_inputs";
 
@@ -54,8 +55,9 @@ pub async fn check_decompress_fs(fname: &str) {
 }
 
 pub async fn check_decompress_seek(fname: &str) {
-    let mut file = File::open(fname).await.unwrap();
-    let mut zip = seek::ZipFileReader::new(&mut file).await.unwrap();
+    let file = File::open(fname).await.unwrap();
+    let mut file_compat = file.compat();
+    let mut zip = seek::ZipFileReader::new(&mut file_compat).await.unwrap();
     let zip_entries: Vec<_> = zip.file().entries().into_iter().cloned().collect();
     for (idx, entry) in zip_entries.into_iter().enumerate() {
         if entry.entry().dir() {


### PR DESCRIPTION
Addresses #17.

This does not attempt to add the feature-gated `tokio` module that the issue postulated. Using the `tokio_util::compat`-provided traits directly seems to work well (at least for me), so it is unclear to me if a special runtime-specific set of APIs is really warranted. But if you consider that to be necessary for seamless updates downstream, then it should be easy to add that in on top of this work. 🙂 

The 'fs' feature now enables the 'tokio' dependency implicitly. Therefore, I would suggest renaming the feature to 'tokio-fs' and perhaps renaming the `async_zip::read::fs` module to `async_zip::read::tokio_fs`.