### PR TITLE
Small fix for missing Zip64 EOCDR / EOCDL if cumulative size > 4Gib and all entrys are < 4Gib

### DIFF
--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -124,20 +124,20 @@ fn get_combined_sizes(
     uncompressed_size: u32,
     compressed_size: u32,
     extra_field: &Option<&Zip64ExtendedInformationExtraField>,
-) -> (u64, u64) {
+) -> Result<(u64, u64)> {
     let mut uncompressed_size = uncompressed_size as u64;
     let mut compressed_size = compressed_size as u64;
 
     if let Some(extra_field) = extra_field {
         if uncompressed_size == NON_ZIP64_MAX_SIZE as u64 {
-            uncompressed_size = extra_field.uncompressed_size;
+            uncompressed_size = extra_field.uncompressed_size.ok_or_else(|| ZipError::Zip64ExtendedFieldIncomplete)?
         }
         if compressed_size == NON_ZIP64_MAX_SIZE as u64 {
-            compressed_size = extra_field.compressed_size;
+            compressed_size = extra_field.compressed_size.ok_or_else(|| ZipError::Zip64ExtendedFieldIncomplete)?;
         }
     }
 
-    (uncompressed_size, compressed_size)
+    Ok((uncompressed_size, compressed_size))
 }
 
 pub(crate) async fn cd_record<R>(mut reader: R, _zip64: bool) -> Result<StoredZipEntry>
@@ -155,7 +155,7 @@ where
 
     let zip64_extra_field = get_zip64_extra_field(&extra_fields);
     let (uncompressed_size, compressed_size) =
-        get_combined_sizes(header.uncompressed_size, header.compressed_size, &zip64_extra_field);
+        get_combined_sizes(header.uncompressed_size, header.compressed_size, &zip64_extra_field)?;
 
     let mut file_offset = header.lh_offset as u64;
     if let Some(zip64_extra_field) = zip64_extra_field {
@@ -210,7 +210,7 @@ where
 
     let zip64_extra_field = get_zip64_extra_field(&extra_fields);
     let (uncompressed_size, compressed_size) =
-        get_combined_sizes(header.uncompressed_size, header.compressed_size, &zip64_extra_field);
+        get_combined_sizes(header.uncompressed_size, header.compressed_size, &zip64_extra_field)?;
 
     if header.flags.data_descriptor {
         return Err(ZipError::FeatureNotSupported(

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -80,8 +80,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                 Zip64ExtendedInformationExtraField {
                     header_id: HeaderId::Zip64ExtendedInformationExtraField,
                     data_size: 16,
-                    uncompressed_size: entry.uncompressed_size,
-                    compressed_size: entry.compressed_size,
+                    uncompressed_size: Some(entry.uncompressed_size),
+                    compressed_size: Some(entry.compressed_size),
                     relative_header_offset: None,
                     disk_start_number: None,
                 },
@@ -158,8 +158,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                         Zip64ExtendedInformationExtraField {
                             header_id: HeaderId::Zip64ExtendedInformationExtraField,
                             data_size: 16,
-                            uncompressed_size,
-                            compressed_size,
+                            uncompressed_size: Some(compressed_size),
+                            compressed_size: Some(compressed_size),
                             relative_header_offset: None,
                             disk_start_number: None,
                         },
@@ -168,8 +168,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                         self.entry.extra_fields().count_bytes().try_into().map_err(|_| ZipError::ExtraFieldTooLarge)?;
                 }
                 Some(zip64) => {
-                    zip64.uncompressed_size = uncompressed_size;
-                    zip64.compressed_size = compressed_size;
+                    zip64.uncompressed_size = Some(uncompressed_size);
+                    zip64.compressed_size = Some(compressed_size);
                 }
             }
 

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -4,16 +4,13 @@
 use crate::base::write::{CentralDirectoryEntry, ZipFileWriter};
 use crate::entry::ZipEntry;
 use crate::error::{Result, Zip64ErrorCase, ZipError};
+use crate::spec::extra_field::Zip64ExtendedInformationExtraFieldBuilder;
 use crate::spec::{
     extra_field::ExtraFieldAsBytes,
-    header::{
-        CentralDirectoryRecord, ExtraField, GeneralPurposeFlag, HeaderId, LocalFileHeader,
-        Zip64ExtendedInformationExtraField,
-    },
+    header::{CentralDirectoryRecord, ExtraField, GeneralPurposeFlag, LocalFileHeader},
     Compression,
 };
-use crate::string::StringEncoding;
-
+use crate::StringEncoding;
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
 use futures_util::io::Cursor;
 
@@ -46,29 +43,72 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             }
         };
 
-        let (lfh_compressed_size, lfh_uncompressed_size) = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
-            || compressed_data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
-        {
+        let mut zip64_extra_field_builder = None;
+
+        let lfh_uncompressed_size = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64 {
             if self.writer.force_no_zip64 {
                 return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
             }
             if !self.writer.is_zip64 {
                 self.writer.is_zip64 = true;
             }
-            self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformationExtraField(
-                Zip64ExtendedInformationExtraField {
-                    header_id: HeaderId::Zip64ExtendedInformationExtraField,
-                    data_size: 16,
-                    uncompressed_size: self.data.len() as u64,
-                    compressed_size: compressed_data.len() as u64,
-                    relative_header_offset: None,
-                    disk_start_number: None,
-                },
-            ));
-            (NON_ZIP64_MAX_SIZE, NON_ZIP64_MAX_SIZE)
+            zip64_extra_field_builder =
+                Some(Zip64ExtendedInformationExtraFieldBuilder::new().uncompressed_size(self.data.len() as u64));
+            NON_ZIP64_MAX_SIZE
         } else {
-            (compressed_data.len() as u32, self.data.len() as u32)
+            self.data.len() as u32
         };
+
+        let lfh_compressed_size = if compressed_data.len() as u64 >= NON_ZIP64_MAX_SIZE as u64 {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
+
+            if let Some(zip64_extra_field) = zip64_extra_field_builder {
+                zip64_extra_field_builder = Some(zip64_extra_field.compressed_size(compressed_data.len() as u64));
+            } else {
+                zip64_extra_field_builder = Some(
+                    Zip64ExtendedInformationExtraFieldBuilder::new().compressed_size(compressed_data.len() as u64),
+                );
+            }
+            NON_ZIP64_MAX_SIZE
+        } else {
+            compressed_data.len() as u32
+        };
+
+        let lh_offset = if self.writer.writer.offset() > NON_ZIP64_MAX_SIZE as usize {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
+
+            if let Some(zip64_extra_field) = zip64_extra_field_builder {
+                zip64_extra_field_builder =
+                    Some(zip64_extra_field.relative_header_offset(self.writer.writer.offset() as u64));
+            } else {
+                zip64_extra_field_builder = Some(
+                    Zip64ExtendedInformationExtraFieldBuilder::new()
+                        .relative_header_offset(self.writer.writer.offset() as u64),
+                );
+            }
+            NON_ZIP64_MAX_SIZE
+        } else {
+            self.writer.writer.offset() as u32
+        };
+
+        if let Some(builder) = zip64_extra_field_builder {
+            if !builder.eof_only() {
+                self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformationExtraField(builder.build()?));
+                zip64_extra_field_builder = None;
+            } else {
+                zip64_extra_field_builder = Some(builder);
+            }
+        }
 
         let lf_header = LocalFileHeader {
             compressed_size: lfh_compressed_size,
@@ -99,7 +139,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             },
         };
 
-        let header = CentralDirectoryRecord {
+        let mut header = CentralDirectoryRecord {
             v_made_by: crate::spec::version::as_made_by(),
             v_needed: lf_header.version,
             compressed_size: lf_header.compressed_size,
@@ -121,7 +161,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             disk_start: 0,
             inter_attr: self.entry.internal_file_attribute(),
             exter_attr: self.entry.external_file_attribute(),
-            lh_offset: self.writer.writer.offset() as u32,
+            lh_offset,
         };
 
         self.writer.writer.write_all(&crate::spec::consts::LFH_SIGNATURE.to_le_bytes()).await?;
@@ -129,6 +169,12 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
         self.writer.writer.write_all(self.entry.filename().as_bytes()).await?;
         self.writer.writer.write_all(&self.entry.extra_fields().as_bytes()).await?;
         self.writer.writer.write_all(compressed_data).await?;
+
+        if let Some(builder) = zip64_extra_field_builder {
+            self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformationExtraField(builder.build()?));
+            header.extra_field_length =
+                self.entry.extra_fields().count_bytes().try_into().map_err(|_| ZipError::ExtraFieldTooLarge)?;
+        }
 
         self.writer.cd_entries.push(CentralDirectoryEntry { header, entry: self.entry });
         // Ensure that we can fit this many files in this archive if forcing no zip64
@@ -140,7 +186,6 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
                 self.writer.is_zip64 = true;
             }
         }
-
         Ok(())
     }
 }

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -45,7 +45,9 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
 
         let mut zip64_extra_field_builder = None;
 
-        let (lfh_uncompressed_size, lfh_compressed_size) = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64 {
+        let (lfh_uncompressed_size, lfh_compressed_size) = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
+            || compressed_data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
+        {
             if self.writer.force_no_zip64 {
                 return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
             }

--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -160,13 +160,9 @@ impl Zip64ExtendedInformationExtraFieldBuilder {
         }
     }
 
-    pub fn uncompressed_size(mut self, uncompressed_size: u64) -> Self {
-        self.field.uncompressed_size = Some(uncompressed_size);
-        self
-    }
-
-    pub fn compressed_size(mut self, compressed_size: u64) -> Self {
+    pub fn sizes(mut self, compressed_size: u64, uncompressed_size: u64) -> Self {
         self.field.compressed_size = Some(compressed_size);
+        self.field.uncompressed_size = Some(uncompressed_size);
         self
     }
 

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -46,11 +46,11 @@ pub enum ExtraField {
 pub struct Zip64ExtendedInformationExtraField {
     pub header_id: HeaderId,
     pub data_size: u16,
-    pub uncompressed_size: u64,
-    pub compressed_size: u64,
+    pub uncompressed_size: Option<u64>,
+    pub compressed_size: Option<u64>,
     // While not specified in the spec, these two fields are often left out in practice.
     pub relative_header_offset: Option<u64>,
-    pub disk_start_number: Option<u64>,
+    pub disk_start_number: Option<u32>,
 }
 
 /// Represents any unparsed extra field.

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -71,8 +71,8 @@ async fn test_write_large_zip64_file() {
     let cd_entry = writer.cd_entries.last().unwrap();
     match &cd_entry.entry.extra_fields.last().unwrap() {
         ExtraField::Zip64ExtendedInformationExtraField(zip64) => {
-            assert_eq!(zip64.compressed_size, BATCHED_FILE_SIZE as u64);
-            assert_eq!(zip64.uncompressed_size, BATCHED_FILE_SIZE as u64);
+            assert_eq!(zip64.compressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
+            assert_eq!(zip64.uncompressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
         }
         e => panic!("Expected a Zip64 extended field, got {:?}", e),
     }


### PR DESCRIPTION
This is a very small PR that fixes https://github.com/Majored/rs-async-zip/issues/105 .

## Explanation:

If the cumulative file size of all zip entrys exceeds the 4 Gib maximum for standard Zip a Zip64 EOCDR & EOCDL is needed.

This was not set automatically if no single entry exceeded the limit, the PR fixes this by checking the `force_no_zip64` flag and updating the `is_zip64` boolean if its allowed, otherwise the `LargeFile` error is raised:

```rust
if cd_offset > NON_ZIP64_MAX_SIZE as u64 {
    if self.force_no_zip64 {
        return Err(crate::error::ZipError::Zip64Needed(crate::error::Zip64ErrorCase::LargeFile));
    } else {
        self.is_zip64 = true;
    }
}
```

Afterwards the correct EOCDR & EOCDL for Zip64 will be added.

## Additional Problem

#105 revealed an additional problem with Zip64 handling:

Zip64 is needed in one of the following cases:

- (A) One entry is above 4 GiB either compressed or uncompressed
- (B) The offset that points to the start of an entry is beyond 4Gib in the file (this is specified in the central directory file header)

The previous implementation checked only if A was the case and completely ignored B. The specification says that if the compressed and uncompressed sizes are below 4 Gib the regular fields in the file headers can (and should) be used [[ref]](https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#453). 

The actual problem was as expected the `lh_offset` in the central directory file header. This needed to be upper bounded to `NON_ZIP64_MAX_SIZE` but additionally a Zip64 extended extra field with `relative_header_offset` was needed (to specify the u64 offset for the actual beginning of the entry).

This  is only required in the Central directory and does not need to be added in the local file header that comes in front of the raw data, "valid" fields from the regular format should be skipped completely (in order) in the Zip64 extra fields. Since both compressed and uncompressed sizes are valid no Zip64 extra field is necessary in the local file header. The extra field is only required in the CD file header.

### Fix

https://github.com/Majored/rs-async-zip/pull/106/commits/6118ad7b613395c56f735e33a605dc54f12abd7e / https://github.com/Majored/rs-async-zip/pull/106/commits/3e080b736c7ca843bc7a0bbad5d7126df1d828d6 fix this issue by creating a `Zip64ExtendedInformationExtraFieldBuilder` that keeps track of the added options and creates a valid ZIP64  extra entry via its `build` method.

If only case B occurs, the extra information is purely added to the central directory file header. If A is the case (with or without B) the local file header is extended by a Zip64 extra entry. The builder also keeps track of the actual expected `data_size` and removes the need for the hard-coded `16 bytes` (because a pure `relative_header_offset` is only 8 bytes and relative offset + sizes is 24 bytes (8 + 16) in addition to the 16 bytes for (uncompressed + compressed) sizes only.

**Caveat**: This is more or less just a PoC additional tests especially for the `entry_stream` are needed to verify that Zip64 handling now behaves correctly. 