### PR TITLE
Fix a bug in zip64 parsing

### DIFF
--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -158,7 +158,7 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                         Zip64ExtendedInformationExtraField {
                             header_id: HeaderId::Zip64ExtendedInformationExtraField,
                             data_size: 16,
-                            uncompressed_size: Some(compressed_size),
+                            uncompressed_size: Some(uncompressed_size),
                             compressed_size: Some(compressed_size),
                             relative_header_offset: None,
                             disk_start_number: None,

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -264,7 +264,7 @@ impl Zip64EndOfCentralDirectoryLocator {
 }
 
 /// Parse the extra fields.
-pub fn parse_extra_fields(data: Vec<u8>) -> Result<Vec<ExtraField>> {
+pub fn parse_extra_fields(data: Vec<u8>, uncompressed_size: u32, compressed_size: u32) -> Result<Vec<ExtraField>> {
     let mut cursor = 0;
     let mut extra_fields = Vec::new();
     while cursor + 4 < data.len() {
@@ -274,7 +274,7 @@ pub fn parse_extra_fields(data: Vec<u8>) -> Result<Vec<ExtraField>> {
             return Err(ZipError::InvalidExtraFieldHeader(field_size, data.len() - cursor - 8 - field_size as usize));
         }
         let data = &data[cursor + 4..cursor + 4 + field_size as usize];
-        extra_fields.push(extra_field_from_bytes(header_id, field_size, data)?);
+        extra_fields.push(extra_field_from_bytes(header_id, field_size, data, uncompressed_size, compressed_size)?);
         cursor += 4 + field_size as usize;
     }
     Ok(extra_fields)


### PR DESCRIPTION
This PR fixes an issue with parsing the Zip64 extended information field. See the linked issue for more details. 

In the future, it may make sense to restructure the extra field parsing to provide header context (e.g. uncompressed size, compressed size, etc) in a cleaner way, but this seemed to be the simplest change to fix this issue.

Fixes #108 

### Test plan

Tested locally with large zip files that failed without this change.