### PR TITLE
Port from futures-util to futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 crc32fast = "1"
-futures-util = { version = "0.3", features = ["io"] }
+futures-lite = { version = "1.13.0", default-features = false, features = ["std"] }
 pin-project = "1"
 thiserror = "1"
 

--- a/examples/actix_multipart.rs
+++ b/examples/actix_multipart.rs
@@ -13,7 +13,7 @@ mod inner {
     use actix_web::{web, App, HttpServer, Responder, ResponseError, Result};
     use derive_more::{Display, Error};
     use futures::StreamExt;
-    use futures_util::io::AsyncWriteExt;
+    use futures_lite::io::AsyncWriteExt;
     use tokio::fs::File;
     use uuid::Uuid;
 

--- a/examples/cli_compress.rs
+++ b/examples/cli_compress.rs
@@ -20,7 +20,7 @@ mod inner {
     use std::path::{Path, PathBuf};
 
     use anyhow::{anyhow, bail, Result};
-    use futures_util::io::AsyncReadExt;
+    use futures_lite::io::AsyncReadExt;
     use tokio::fs::File;
 
     async fn run() -> Result<()> {

--- a/examples/file_extraction.rs
+++ b/examples/file_extraction.rs
@@ -69,7 +69,7 @@ async fn unzip_file(archive: File, out_dir: &Path) {
                 .open(&path)
                 .await
                 .expect("Failed to create extracted file");
-            futures_util::io::copy(&mut entry_reader, &mut writer.compat_write())
+            futures_lite::io::copy(&mut entry_reader, &mut writer.compat_write())
                 .await
                 .expect("Failed to copy to extracted file");
 

--- a/src/base/read/io/compressed.rs
+++ b/src/base/read/io/compressed.rs
@@ -15,7 +15,7 @@ use std::task::{Context, Poll};
     feature = "deflate64"
 ))]
 use async_compression::futures::bufread;
-use futures_util::io::{AsyncBufRead, AsyncRead};
+use futures_lite::io::{AsyncBufRead, AsyncRead};
 use pin_project::pin_project;
 
 /// A wrapping reader which holds concrete types for all respective compression method readers.

--- a/src/base/read/io/entry.rs
+++ b/src/base/read/io/entry.rs
@@ -9,7 +9,7 @@ use crate::spec::Compression;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::io::{AsyncRead, AsyncReadExt, BufReader, Take};
+use futures_lite::io::{AsyncRead, AsyncReadExt, BufReader, Take};
 use pin_project::pin_project;
 
 /// A type which encodes that [`ZipEntryReader`] has associated entry data.

--- a/src/base/read/io/hashed.rs
+++ b/src/base/read/io/hashed.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
 use crc32fast::Hasher;
-use futures_util::io::AsyncRead;
+use futures_lite::io::AsyncRead;
 use pin_project::pin_project;
 
 /// A wrapping reader which computes the CRC32 hash of data read via [`AsyncRead`].

--- a/src/base/read/io/locator.rs
+++ b/src/base/read/io/locator.rs
@@ -18,7 +18,7 @@
 //! of a better algorithm for this (and have tested/verified its performance).
 
 #[cfg(doc)]
-use futures_util::io::BufReader;
+use futures_lite::io::BufReader;
 
 use crate::error::{Result as ZipResult, ZipError};
 use crate::spec::consts::{EOCDR_LENGTH, EOCDR_SIGNATURE, SIGNATURE_LENGTH};

--- a/src/base/read/io/locator.rs
+++ b/src/base/read/io/locator.rs
@@ -23,7 +23,7 @@ use futures_util::io::BufReader;
 use crate::error::{Result as ZipResult, ZipError};
 use crate::spec::consts::{EOCDR_LENGTH, EOCDR_SIGNATURE, SIGNATURE_LENGTH};
 
-use futures_util::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
+use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
 /// The buffer size used when locating the EOCDR, equal to 2KiB.
 const BUFFER_SIZE: usize = 2048;

--- a/src/base/read/io/mod.rs
+++ b/src/base/read/io/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod owned;
 pub use combined_record::CombinedCentralDirectoryRecord;
 
 use crate::string::{StringEncoding, ZipString};
-use futures_util::io::{AsyncRead, AsyncReadExt};
+use futures_lite::io::{AsyncRead, AsyncReadExt};
 
 /// Read and return a dynamic length string from a reader which impls AsyncRead.
 pub(crate) async fn read_string<R>(reader: R, length: usize, encoding: StringEncoding) -> std::io::Result<ZipString>

--- a/src/base/read/io/owned.rs
+++ b/src/base/read/io/owned.rs
@@ -4,7 +4,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::io::{AsyncBufRead, AsyncRead, BufReader};
+use futures_lite::io::{AsyncBufRead, AsyncRead, BufReader};
 use pin_project::pin_project;
 
 /// A wrapping reader which holds an owned R or a mutable borrow to R.

--- a/src/base/read/mem.rs
+++ b/src/base/read/mem.rs
@@ -17,7 +17,7 @@
 //! ```no_run
 //! # use async_zip::base::read::mem::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use futures_util::io::AsyncReadExt;
+//! # use futures_lite::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new(Vec::new()).await?;
@@ -43,7 +43,7 @@
 //! ```no_run
 //! # use async_zip::base::read::mem::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use futures_util::io::AsyncReadExt;
+//! # use futures_lite::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new(Vec::new()).await?;

--- a/src/base/read/mem.rs
+++ b/src/base/read/mem.rs
@@ -76,7 +76,7 @@ use crate::file::ZipFile;
 
 use std::sync::Arc;
 
-use futures_util::io::{BufReader, Cursor};
+use futures_lite::io::{BufReader, Cursor};
 
 use super::io::entry::{WithEntry, WithoutEntry};
 

--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -33,7 +33,7 @@ use crate::string::StringEncoding;
 use crate::base::read::io::CombinedCentralDirectoryRecord;
 use crate::spec::parse::parse_extra_fields;
 
-use futures_util::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, SeekFrom};
+use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, SeekFrom};
 
 /// The max buffer size used when parsing the central directory, equal to 20MiB.
 const MAX_CD_BUFFER_SIZE: usize = 20 * 1024 * 1024;

--- a/src/base/read/seek.rs
+++ b/src/base/read/seek.rs
@@ -7,7 +7,7 @@
 //! ```no_run
 //! # use async_zip::base::read::seek::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use futures_util::io::AsyncReadExt;
+//! # use futures_lite::io::AsyncReadExt;
 //! # use tokio::fs::File;
 //! # use tokio_util::compat::TokioAsyncReadCompatExt;
 //! #

--- a/src/base/read/seek.rs
+++ b/src/base/read/seek.rs
@@ -32,7 +32,7 @@ use crate::file::ZipFile;
 #[cfg(feature = "tokio")]
 use crate::tokio::read::seek::ZipFileReader as TokioZipFileReader;
 
-use futures_util::io::{AsyncRead, AsyncSeek, BufReader};
+use futures_lite::io::{AsyncRead, AsyncSeek, BufReader};
 
 #[cfg(feature = "tokio")]
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};

--- a/src/base/read/stream.rs
+++ b/src/base/read/stream.rs
@@ -29,7 +29,7 @@
 //!
 //! # Example
 //! ```no_run
-//! # use futures_util::io::Cursor;
+//! # use futures_lite::io::Cursor;
 //! # use async_zip::error::Result;
 //! # use async_zip::base::read::stream::ZipFileReader;
 //! #

--- a/src/base/read/stream.rs
+++ b/src/base/read/stream.rs
@@ -53,9 +53,9 @@ use crate::error::ZipError;
 #[cfg(feature = "tokio")]
 use crate::tokio::read::stream::Ready as TokioReady;
 
-use futures_util::io::AsyncReadExt;
-use futures_util::io::Take;
-use futures_util::io::{AsyncRead, BufReader};
+use futures_lite::io::AsyncReadExt;
+use futures_lite::io::Take;
+use futures_lite::io::{AsyncRead, BufReader};
 
 #[cfg(feature = "tokio")]
 use tokio_util::compat::TokioAsyncReadCompatExt;

--- a/src/base/write/compressed_writer.rs
+++ b/src/base/write/compressed_writer.rs
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
 use async_compression::futures::write;
-use futures_util::io::AsyncWrite;
+use futures_lite::io::AsyncWrite;
 
 pub enum CompressedAsyncWriter<'b, W: AsyncWrite + Unpin> {
     Stored(ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>),

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -25,7 +25,7 @@ use std::task::{Context, Poll};
 use crate::base::read::get_zip64_extra_field_mut;
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
 use crc32fast::Hasher;
-use futures_util::io::{AsyncWrite, AsyncWriteExt};
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
 
 /// An entry writer which supports the streaming of data (ie. the writing of unknown size or data at runtime).
 ///

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -20,7 +20,7 @@ use futures_util::io::Cursor;
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
 use async_compression::futures::write;
-use futures_util::io::{AsyncWrite, AsyncWriteExt};
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
 
 pub struct EntryWholeWriter<'b, 'c, W: AsyncWrite + Unpin> {
     writer: &'b mut ZipFileWriter<W>,

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -15,7 +15,7 @@ use crate::spec::{
 };
 use crate::StringEncoding;
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
-use futures_util::io::Cursor;
+use futures_lite::io::Cursor;
 
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
 #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]

--- a/src/base/write/io/offset.rs
+++ b/src/base/write/io/offset.rs
@@ -5,7 +5,7 @@ use std::io::{Error, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_util::io::AsyncWrite;
+use futures_lite::io::AsyncWrite;
 use pin_project::pin_project;
 
 /// A wrapper around an [`AsyncWrite`] implementation which tracks the current byte offset.

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -74,7 +74,7 @@ use entry_whole::EntryWholeWriter;
 use io::offset::AsyncOffsetWriter;
 
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
-use futures_util::io::{AsyncWrite, AsyncWriteExt};
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
 
 pub(crate) struct CentralDirectoryEntry {
     pub header: CentralDirectoryRecord,

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -30,7 +30,7 @@
 //! # use async_zip::{Compression, ZipEntryBuilder, base::write::ZipFileWriter};
 //! # use std::io::Cursor;
 //! # use async_zip::error::ZipError;
-//! # use futures_util::io::AsyncWriteExt;
+//! # use futures_lite::io::AsyncWriteExt;
 //! # use tokio_util::compat::TokioAsyncWriteCompatExt;
 //! #
 //! # async fn run() -> Result<(), ZipError> {

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -5,7 +5,7 @@ pub mod builder;
 
 use std::ops::Deref;
 
-use futures_util::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
+use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
 use crate::entry::builder::ZipEntryBuilder;
 use crate::error::{Result, ZipError};

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -7,7 +7,7 @@ use crate::spec::header::{
     Zip64EndOfCentralDirectoryLocator, Zip64EndOfCentralDirectoryRecord,
 };
 
-use futures_util::io::{AsyncRead, AsyncReadExt};
+use futures_lite::io::{AsyncRead, AsyncReadExt};
 
 impl LocalFileHeader {
     pub fn as_slice(&self) -> [u8; 26] {

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -331,7 +331,7 @@ mod tests {
             0x50, 0x4B, 0x06, 0x07, 0x00, 0x00, 0x00, 0x00, 0x6F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
             0x00, 0x00,
         ];
-        let mut cursor = futures_util::io::Cursor::new(eocdl);
+        let mut cursor = futures_lite::io::Cursor::new(eocdl);
         let zip64eocdl = Zip64EndOfCentralDirectoryLocator::try_from_reader(&mut cursor).await.unwrap().unwrap();
         assert_eq!(
             zip64eocdl,

--- a/src/tests/read/compression/mod.rs
+++ b/src/tests/read/compression/mod.rs
@@ -27,7 +27,7 @@ macro_rules! compressed_test_helper {
         #[cfg(test)]
         #[tokio::test]
         async fn $name() {
-            use futures_util::io::{AsyncReadExt, Cursor};
+            use futures_lite::io::{AsyncReadExt, Cursor};
 
             let data = $data;
             let data_raw = $data_raw;

--- a/src/tests/read/locator/mod.rs
+++ b/src/tests/read/locator/mod.rs
@@ -29,7 +29,7 @@ fn search_two_byte_test() {
 
 #[tokio::test]
 async fn locator_empty_test() {
-    use futures_util::io::Cursor;
+    use futures_lite::io::Cursor;
 
     let data = &include_bytes!("empty.zip");
     let mut cursor = Cursor::new(data);
@@ -41,7 +41,7 @@ async fn locator_empty_test() {
 
 #[tokio::test]
 async fn locator_empty_max_comment_test() {
-    use futures_util::io::Cursor;
+    use futures_lite::io::Cursor;
 
     let data = &include_bytes!("empty-with-max-comment.zip");
     let mut cursor = Cursor::new(data);
@@ -53,7 +53,7 @@ async fn locator_empty_max_comment_test() {
 
 #[tokio::test]
 async fn locator_buffer_boundary_test() {
-    use futures_util::io::Cursor;
+    use futures_lite::io::Cursor;
 
     let data = &include_bytes!("empty-buffer-boundary.zip");
     let mut cursor = Cursor::new(data);

--- a/src/tests/read/zip64/mod.rs
+++ b/src/tests/read/zip64/mod.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023 Cognite AS
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use futures_util::io::AsyncReadExt;
+use futures_lite::io::AsyncReadExt;
 
 use crate::tests::init_logger;
 

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use futures_util::io::AsyncWrite;
+use futures_lite::io::AsyncWrite;
 use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/tests/write/offset/mod.rs
+++ b/src/tests/write/offset/mod.rs
@@ -5,8 +5,8 @@ use crate::base::write::io::offset::AsyncOffsetWriter;
 
 #[tokio::test]
 async fn basic() {
-    use futures_util::io::AsyncWriteExt;
-    use futures_util::io::Cursor;
+    use futures_lite::io::AsyncWriteExt;
+    use futures_lite::io::Cursor;
 
     let mut writer = AsyncOffsetWriter::new(Cursor::new(Vec::new()));
     assert_eq!(writer.offset(), 0);

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -9,7 +9,7 @@ use crate::{Compression, ZipEntryBuilder};
 use std::io::Read;
 
 use crate::spec::header::ExtraField;
-use futures_util::io::AsyncWriteExt;
+use futures_lite::io::AsyncWriteExt;
 
 // Useful constants for writing a large file.
 const BATCH_SIZE: usize = 100_000;
@@ -100,7 +100,7 @@ async fn test_write_large_zip64_file() {
 /// Test writing a file, and reading it with async-zip
 #[tokio::test]
 async fn test_write_large_zip64_file_self_read() {
-    use futures_util::io::AsyncReadExt;
+    use futures_lite::io::AsyncReadExt;
 
     init_logger();
 

--- a/src/tokio/read/fs.rs
+++ b/src/tokio/read/fs.rs
@@ -17,7 +17,7 @@
 //! ```no_run
 //! # use async_zip::tokio::read::fs::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use futures_util::io::AsyncReadExt;
+//! # use futures_lite::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new("./foo.zip").await?;
@@ -43,7 +43,7 @@
 //! ```no_run
 //! # use async_zip::tokio::read::fs::ZipFileReader;
 //! # use async_zip::error::Result;
-//! # use futures_util::io::AsyncReadExt;
+//! # use futures_lite::io::AsyncReadExt;
 //! #
 //! async fn run() -> Result<()> {
 //!     let reader = ZipFileReader::new("./foo.zip").await?;
@@ -77,7 +77,7 @@ use crate::file::ZipFile;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use futures_util::io::BufReader;
+use futures_lite::io::BufReader;
 use tokio::fs::File;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use crate::error::{Result, ZipError};
-use futures_util::io::{AsyncRead, AsyncReadExt};
+use futures_lite::io::{AsyncRead, AsyncReadExt};
 
 // Assert that the next four-byte signature read by a reader which impls AsyncRead matches the expected signature.
 pub(crate) async fn assert_signature<R: AsyncRead + Unpin>(reader: &mut R, expected: u32) -> Result<()> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ use async_zip::base::read::seek;
 use async_zip::base::write::ZipFileWriter;
 use async_zip::Compression;
 use async_zip::ZipEntryBuilder;
-use futures_util::io::AsyncWriteExt;
+use futures_lite::io::AsyncWriteExt;
 use tokio::fs::File;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 

--- a/tests/compress_test.rs
+++ b/tests/compress_test.rs
@@ -2,7 +2,7 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use async_zip::{Compression, ZipEntryBuilder, ZipString};
-use futures_util::AsyncWriteExt;
+use futures_lite::AsyncWriteExt;
 
 mod common;
 


### PR DESCRIPTION
futures-lite is a subset of futures-util that is smaller and compiles much faster.