### PR TITLE
add entry header size

### DIFF
--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -150,6 +150,7 @@ where
     crate::utils::assert_signature(&mut reader, CDH_SIGNATURE).await?;
 
     let header = CentralDirectoryRecord::from_reader(&mut reader).await?;
+    let header_size = 30 + header.file_name_length + header.extra_field_length;
     let filename_basic = io::read_bytes(&mut reader, header.file_name_length.into()).await?;
     let compression = Compression::try_from(header.compression)?;
     let extra_field = io::read_bytes(&mut reader, header.extra_field_length.into()).await?;
@@ -197,7 +198,7 @@ where
     };
 
     // general_purpose_flag: header.flags,
-    Ok(StoredZipEntry { entry, file_offset })
+    Ok(StoredZipEntry { entry, file_offset, header_size })
 }
 
 pub(crate) async fn lfh<R>(mut reader: R) -> Result<Option<ZipEntry>>

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -202,9 +202,15 @@ impl StoredZipEntry {
         // Skip the local file header and trailing data
         let header = LocalFileHeader::from_reader(&mut reader).await?;
 
-        let extra = (self.header_size - 30) as usize;
+        // Found zip64.zip's CDS and LFH 's Extra field length not equal
+        let mut record_ignore = self.header_size - 30;
+        let locol_ignore =header.file_name_length+header.extra_field_length;
 
-        let _extra_field = crate::base::read::io::read_bytes(&mut reader, extra).await?;
+        if record_ignore != locol_ignore {
+            record_ignore = locol_ignore;
+        }
+
+        let _extra_field = crate::base::read::io::read_bytes(&mut reader, record_ignore as usize).await?;
 
         Ok(())
     }

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -168,12 +168,18 @@ pub struct StoredZipEntry {
     pub(crate) entry: ZipEntry,
     // pub(crate) general_purpose_flag: GeneralPurposeFlag,
     pub(crate) file_offset: u64,
+    pub(crate) header_size: u16,
 }
 
 impl StoredZipEntry {
     /// Returns the offset in bytes to where the header of the entry starts.
     pub fn header_offset(&self) -> u64 {
         self.file_offset
+    }
+
+    /// Returns the size in bytes where the header of the entry.
+    pub fn header_size(&self) -> u16 {
+        self.header_size
     }
 
     /// Seek to the offset in bytes where the data of the entry starts.

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -204,7 +204,7 @@ impl StoredZipEntry {
 
         // Found zip64.zip's CDS and LFH 's Extra field length not equal
         let mut record_ignore = self.header_size - 30;
-        let locol_ignore =header.file_name_length+header.extra_field_length;
+        let locol_ignore = header.file_name_length + header.extra_field_length;
 
         if record_ignore != locol_ignore {
             record_ignore = locol_ignore;

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -201,10 +201,10 @@ impl StoredZipEntry {
 
         // Skip the local file header and trailing data
         let header = LocalFileHeader::from_reader(&mut reader).await?;
-
-        let extra = (self.header_size - 30) as usize;
-
-        let _extra_field = crate::base::read::io::read_bytes(&mut reader, extra).await?;
+        let _filename =
+            crate::base::read::io::read_string(&mut reader, header.file_name_length.into(), StringEncoding::Utf8)
+                .await?;
+        let _extra_field = crate::base::read::io::read_bytes(&mut reader, header.extra_field_length.into()).await?;
 
         Ok(())
     }

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -201,10 +201,10 @@ impl StoredZipEntry {
 
         // Skip the local file header and trailing data
         let header = LocalFileHeader::from_reader(&mut reader).await?;
-        let _filename =
-            crate::base::read::io::read_string(&mut reader, header.file_name_length.into(), StringEncoding::Utf8)
-                .await?;
-        let _extra_field = crate::base::read::io::read_bytes(&mut reader, header.extra_field_length.into()).await?;
+
+        let extra = (self.header_size - 30) as usize;
+
+        let _extra_field = crate::base::read::io::read_bytes(&mut reader, extra).await?;
 
         Ok(())
     }

--- a/tests/decompress_test.rs
+++ b/tests/decompress_test.rs
@@ -81,6 +81,7 @@ async fn decompress_zip_with_utf8_extra() {
     let zip = async_zip::base::read::seek::ZipFileReader::new(&mut file_compat).await.unwrap();
     let zip_entries: Vec<_> = zip.file().entries().to_vec();
     assert_eq!(zip_entries.len(), 1);
+    assert_eq!(zip_entries[0].header_size(), 93);
     assert_eq!(zip_entries[0].filename().as_str().unwrap(), "\u{4E2D}\u{6587}.txt");
     assert_eq!(zip_entries[0].filename().alternative(), Some(b"\xD6\xD0\xCe\xC4.txt".as_ref()));
 }


### PR DESCRIPTION
when I partly download a zip file, I has know the compress  format ,and I only want the compressed file part from the whole file.
I can use the 

file_offset+header_size 

to get the file part start. also seems the #113  has the same need , so I make this pr.



I found the failed test is test_read_zip64_archive_mem

the reason is because the `zip64.zip` file 's 
Central directory structure and the Local File Header
it has different value about the Extra field length

so it does not support all zip64 extra.

Shoud I maybe add the header_size on the `ZipEntry` ,not the `StoredZipEntry` ?

