### PR TITLE
Fix for 32bit platforms. Fix for large zip64 archives.

### DIFF
--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -178,7 +178,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
         let (cdr_compressed_size, cdr_uncompressed_size, lh_offset) = if self.force_no_zip64 {
             if uncompressed_size > NON_ZIP64_MAX_SIZE as u64
                 || compressed_size > NON_ZIP64_MAX_SIZE as u64
-                || self.lfh_offset > NON_ZIP64_MAX_SIZE as u64 {
+                || self.lfh_offset > NON_ZIP64_MAX_SIZE as u64
+            {
                 return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
             }
             (uncompressed_size as u32, compressed_size as u32, self.lfh_offset as u32)

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -81,12 +81,11 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             }
 
             if let Some(zip64_extra_field) = zip64_extra_field_builder {
-                zip64_extra_field_builder =
-                    Some(zip64_extra_field.relative_header_offset(self.writer.writer.offset() as u64));
+                zip64_extra_field_builder = Some(zip64_extra_field.relative_header_offset(self.writer.writer.offset()));
             } else {
                 zip64_extra_field_builder = Some(
                     Zip64ExtendedInformationExtraFieldBuilder::new()
-                        .relative_header_offset(self.writer.writer.offset() as u64),
+                        .relative_header_offset(self.writer.writer.offset()),
                 );
             }
             NON_ZIP64_MAX_SIZE

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -72,7 +72,7 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
             (self.data.len() as u32, compressed_data.len() as u32)
         };
 
-        let lh_offset = if self.writer.writer.offset() > NON_ZIP64_MAX_SIZE as usize {
+        let lh_offset = if self.writer.writer.offset() > NON_ZIP64_MAX_SIZE as u64 {
             if self.writer.force_no_zip64 {
                 return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
             }

--- a/src/base/write/io/offset.rs
+++ b/src/base/write/io/offset.rs
@@ -13,7 +13,7 @@ use pin_project::pin_project;
 pub struct AsyncOffsetWriter<W> {
     #[pin]
     inner: W,
-    offset: usize,
+    offset: u64,
 }
 
 impl<W> AsyncOffsetWriter<W>
@@ -26,7 +26,7 @@ where
     }
 
     /// Returns the current byte offset.
-    pub fn offset(&self) -> usize {
+    pub fn offset(&self) -> u64 {
         self.offset
     }
 
@@ -49,7 +49,7 @@ where
         let poll = this.inner.poll_write(cx, buf);
 
         if let Poll::Ready(Ok(inner)) = &poll {
-            *this.offset += inner;
+            *this.offset += *inner as u64;
         }
 
         poll

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -168,7 +168,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
             self.writer.write_all(comment_basic).await?;
         }
 
-        let central_directory_size = (self.writer.offset() - cd_offset) as u64;
+        let central_directory_size = self.writer.offset() - cd_offset;
         let central_directory_size_u32 = if central_directory_size > NON_ZIP64_MAX_SIZE as u64 {
             NON_ZIP64_MAX_SIZE
         } else {
@@ -180,7 +180,6 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
         } else {
             num_entries_in_directory as u16
         };
-        let cd_offset = cd_offset as u64;
         let cd_offset_u32 = if cd_offset > NON_ZIP64_MAX_SIZE as u64 {
             if self.force_no_zip64 {
                 return Err(crate::error::ZipError::Zip64Needed(crate::error::Zip64ErrorCase::LargeFile));
@@ -212,7 +211,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
 
             let eocdl = Zip64EndOfCentralDirectoryLocator {
                 number_of_disk_with_start_of_zip64_end_of_central_directory: 0,
-                relative_offset: eocdr_offset as u64,
+                relative_offset: eocdr_offset,
                 total_number_of_disks: 1,
             };
             self.writer.write_all(&crate::spec::consts::ZIP64_EOCDL_SIGNATURE.to_le_bytes()).await?;

--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -257,14 +257,9 @@ pub(crate) fn extra_field_from_bytes(
     compressed_size: u32,
 ) -> ZipResult<ExtraField> {
     match header_id {
-        HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD => {
-            Ok(ExtraField::Zip64ExtendedInformation(zip64_extended_information_field_from_bytes(
-                header_id,
-                data,
-                uncompressed_size,
-                compressed_size,
-            )?))
-        }
+        HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD => Ok(ExtraField::Zip64ExtendedInformation(
+            zip64_extended_information_field_from_bytes(header_id, data, uncompressed_size, compressed_size)?,
+        )),
         HeaderId::INFO_ZIP_UNICODE_COMMENT_EXTRA_FIELD => Ok(ExtraField::InfoZipUnicodeComment(
             info_zip_unicode_comment_extra_field_from_bytes(header_id, data_size, data)?,
         )),

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -63,12 +63,20 @@ pub enum ExtraField {
 #[derive(Clone, Debug)]
 pub struct Zip64ExtendedInformationExtraField {
     pub header_id: HeaderId,
-    pub data_size: u16,
     pub uncompressed_size: Option<u64>,
     pub compressed_size: Option<u64>,
     // While not specified in the spec, these two fields are often left out in practice.
     pub relative_header_offset: Option<u64>,
     pub disk_start_number: Option<u32>,
+}
+
+impl Zip64ExtendedInformationExtraField {
+    pub(crate) fn content_size(&self) -> usize {
+        self.uncompressed_size.map(|_| 8).unwrap_or_default()
+            + self.compressed_size.map(|_| 8).unwrap_or_default()
+            + self.relative_header_offset.map(|_| 8).unwrap_or_default()
+            + self.disk_start_number.map(|_| 8).unwrap_or_default()
+    }
 }
 
 /// Stores the UTF-8 version of the file comment as stored in the central directory header.


### PR DESCRIPTION
Hello!

This PR fixes problems with usize on 32bit systems(WASM)
Also it fixes problems with local header offset in zip64 archives that are more than 4 gb size.