### PR TITLE
Fix an issue where the EOCDR search could skip bytes

### DIFF
--- a/src/base/read/io/locator.rs
+++ b/src/base/read/io/locator.rs
@@ -55,9 +55,9 @@ where
     reader.seek(SeekFrom::Start(position)).await?;
 
     loop {
-        let read = reader.read(&mut buffer).await?;
+        reader.read_exact(&mut buffer).await?;
 
-        if let Some(match_index) = reverse_search_buffer(&buffer[..read], signature) {
+        if let Some(match_index) = reverse_search_buffer(&buffer, signature) {
             return Ok(position + (match_index + 1) as u64);
         }
 


### PR DESCRIPTION
The current EOCDR search assumes the buffer will be fully filled by using `reader.read`, but the `reader.read` could only partially fill the buffer and return the size of read data. This makes the implementations skip bytes that might contain `EOCDR_SIGNATURE`.

This PR fixes this issue by replacing `reader.read` with `reader.read_exact` to make sure the buffer is fully filled, unless EOF is reached.