### PR TITLE
Implement tokio::AsyncWrite for EntryStreamWriter

### DIFF
--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -251,8 +251,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
     }
 }
 
-impl<'a, W: AsyncWrite + Unpin> AsyncWrite for EntryStreamWriter<'a, W> {
-    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+impl<'a, W: AsyncWrite + Unpin> EntryStreamWriter<'a, W> {
+    fn poll_write_impl(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
         let poll = Pin::new(&mut self.writer).poll_write(cx, buf);
 
         if let Poll::Ready(Ok(written)) = poll {
@@ -262,11 +262,40 @@ impl<'a, W: AsyncWrite + Unpin> AsyncWrite for EntryStreamWriter<'a, W> {
         poll
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+    fn poll_flush_impl(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Error>> {
         Pin::new(&mut self.writer).poll_flush(cx)
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+    fn poll_close_impl(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Error>> {
         Pin::new(&mut self.writer).poll_close(cx)
+    }
+}
+
+impl<'a, W: AsyncWrite + Unpin> AsyncWrite for EntryStreamWriter<'a, W> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        self.poll_write_impl(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        self.poll_flush_impl(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        self.poll_close_impl(cx)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<'a, W: AsyncWrite + Unpin> tokio::io::AsyncWrite for EntryStreamWriter<'a, W> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::result::Result<usize, std::io::Error>> {
+        self.poll_write_impl(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), std::io::Error>> {
+        self.poll_flush_impl(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), std::io::Error>> {
+        self.poll_close_impl(cx)
     }
 }


### PR DESCRIPTION
When creating entries, we cannot use Tokio to write file contents. Fix
that.
