### PR TITLE
Compile and run large-file tests only on 64-bit architectures

### DIFF
--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 pub(crate) mod offset;
+#[cfg(target_pointer_width = "64")]
 mod zip64;
 
 /// /dev/null for AsyncWrite.


### PR DESCRIPTION
This trivial patch was originally written by @decathorpe for Fedora’s [`rust-async_zip`](https://src.fedoraproject.org/rpms/rust-async_zip) package, but I don’t think we ever got around to offering it upstream.

Without this, on 32-bit platforms, `cargo test` fails like:

```
error[E0080]: attempt to compute `42950_usize * 100000_usize`, which would overflow
  --> src/tests/write/zip64/mod.rs:17:34
   |
17 | const BATCHED_FILE_SIZE: usize = NUM_BATCHES * BATCH_SIZE;
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `tests::write::zip64::BATCHED_FILE_SIZE` failed here
note: erroneous constant encountered
  --> src/tests/write/zip64/mod.rs:17:34
   |
17 | const BATCHED_FILE_SIZE: usize = NUM_BATCHES * BATCH_SIZE;
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
  --> src/tests/write/zip64/mod.rs:74:56
   |
74 |             assert_eq!(zip64.compressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
   |                                                        ^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
  --> src/tests/write/zip64/mod.rs:75:58
   |
75 |             assert_eq!(zip64.uncompressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
   |                                                          ^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
  --> src/tests/write/zip64/mod.rs:87:29
   |
87 |     assert_eq!(file.size(), BATCHED_FILE_SIZE as u64);
   |                             ^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
  --> src/tests/write/zip64/mod.rs:97:29
   |
97 |     assert_eq!(bytes_total, BATCHED_FILE_SIZE);
   |                             ^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
   --> src/tests/write/zip64/mod.rs:122:64
    |
122 |     assert_eq!(reader.file().entries[0].entry.compressed_size, BATCHED_FILE_SIZE as u64);
    |                                                                ^^^^^^^^^^^^^^^^^
note: erroneous constant encountered
   --> src/tests/write/zip64/mod.rs:134:29
    |
134 |     assert_eq!(bytes_total, BATCHED_FILE_SIZE);
    |                             ^^^^^^^^^^^^^^^^^
```